### PR TITLE
Added support for binary int literals

### DIFF
--- a/mypy/lex.py
+++ b/mypy/lex.py
@@ -394,8 +394,8 @@ class Lexer:
 
     # Regexps used by lex_number
 
-    # Decimal/hex/octal literal or integer complex literal
-    number_exp1 = re.compile('0[xXoO][0-9a-fA-F]+|[0-9]+')
+    # Decimal/hex/octal/binary literal or integer complex literal
+    number_exp1 = re.compile('0[xXoObB][0-9a-fA-F]+|[0-9]+')
     # Float literal, e.g. '1.23' or '12e+34' or '1.2j'
     number_exp2 = re.compile(
         r'[0-9]*\.[0-9]*([eE][-+]?[0-9]+)?|[0-9]+[eE][-+]?[0-9]+')

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -1268,15 +1268,7 @@ class Parser:
 
     def parse_int_expr(self) -> IntExpr:
         tok = self.expect_type(IntLit)
-        s = tok.string
-        v = 0
-        if len(s) > 2 and s[1] in 'xX':
-            v = int(s[2:], 16)
-        elif len(s) > 2 and s[1] in 'oO':
-            v = int(s[2:], 8)
-        else:
-            v = int(s)
-        node = IntExpr(v)
+        node = IntExpr(int(tok.string, 0))
         return node
 
     def parse_str_expr(self) -> Node:

--- a/mypy/test/data/parse.test
+++ b/mypy/test/data/parse.test
@@ -1665,8 +1665,8 @@ MypyFile:1(
     Block:1(
       PassStmt:2())))
 
-[case testHexAndOctLiterals]
-0xa, 0Xaf, 0o7, 0O12
+[case testHexOctBinLiterals]
+0xa, 0Xaf, 0o7, 0O12, 0b1, 0B101
 [out]
 MypyFile:1(
   ExpressionStmt:1(
@@ -1674,7 +1674,9 @@ MypyFile:1(
       IntExpr(10)
       IntExpr(175)
       IntExpr(7)
-      IntExpr(10))))
+      IntExpr(10)
+      IntExpr(1)
+      IntExpr(5))))
 
 [case testImportFromWithParens]
 from x import (y)

--- a/mypy/test/testlex.py
+++ b/mypy/test/testlex.py
@@ -46,6 +46,10 @@ class LexerSuite(Suite):
         self.assert_lex('0o0 0o127 0O1',
                         'IntLit(0o0) IntLit( 0o127) IntLit( 0O1) ...')
 
+    def test_bin_int_literals(self):
+        self.assert_lex('0b0 0b110 0B1',
+                        'IntLit(0b0) IntLit( 0b110) IntLit( 0B1) ...')
+
     def test_float_literals(self):
         self.assert_lex('1.2 .1 1.',
                         'FloatLit(1.2) FloatLit( .1) FloatLit( 1.) ...')


### PR DESCRIPTION
This should fix #534.

As part of this change, I changed the parsing of int expressions to use `int(token, base=0)`. As noted in the Python [docs](https://docs.python.org/3/library/functions.html#int), "base 0 means to interpret exactly as a code literal, so that the actual base is 2, 8, 10, or 16". This means all four cases are handled in one, and `parse_int_expr` now looks more like `parse_float_expr` and `parse_complex_expr`.

Also, I was going to add a test similar to [`test_invalid_hex_int_literals`](https://github.com/JukkaL/mypy/blob/f319ebb743f23bc7e534fbc9ef8da1466d505d51/mypy/test/testlex.py#L375) for octal and binary literals, but I discovered the lexer currently allows invalid octal literals like `0oA`. The same is true for binary literals after this change. Is it worth updating the regular expression to only allow valid literals? I think something like `0[xX][0-9a-fA-F]+|0[oO][0-7]+|0[bB][01]+|[0-9]+` should work.

This is my first contribution to the project, so please let me know if I have missed anything or if you have any questions.