### PR TITLE
Typo fixes

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -142,7 +142,7 @@ in Java):
 Mypy can't infer the type of ``o`` after the ``isinstance()`` check
 because of the ``and`` operator (this limitation will likely be lifted
 in the future).  We can write the above code without a cast by using a
-nested if statemet:
+nested if statement:
 
 .. code-block:: python
 
@@ -162,6 +162,6 @@ implementing a piece of functionality.
 Type inference in mypy is designed to work well in common cases, to be
 predictable and to let the type checker give useful error
 messages. More powerful type inference strategies often have complex
-and difficult-to-prefict failure modes and could result in very
+and difficult-to-predict failure modes and could result in very
 confusing error messages. The tradeoff is that you as a programmer
 sometimes have to give the type checker a little help.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -6,7 +6,7 @@ Why have both dynamic and static typing?
 
 Dynamic typing can be flexible, powerful, convenient and easy. But
 it's not always the best approach; there are good reasons why many
-developers choose to use staticaly typed languages.
+developers choose to use statically typed languages.
 
 Here are some potential benefits of mypy-style static typing:
 
@@ -80,7 +80,7 @@ Will static typing make my programs run faster?
 Mypy only does static type checking and it does not improve
 performance. It has a minimal performance impact. In the future, there
 could be other tools that can compile statically typed mypy code to C
-modules or to efficient JVM bytecode, for example, but this outside
+modules or to efficient JVM bytecode, for example, but this is outside
 the scope of the mypy project. It may also be possible to modify
 existing Python VMs to take advantage of static type information, but
 whether this is feasible is still unknown. This is nontrivial since

--- a/docs/source/function_overloading.rst
+++ b/docs/source/function_overloading.rst
@@ -21,7 +21,7 @@ yet) using the ``@overload`` decorator. For example, we can define an
    def abs(n: float) -> float: pass
 
 Note that we can't use ``Union[int, float]`` as the argument type,
-since this wouldn't allow us to express that the the return
+since this wouldn't allow us to express that the return
 type depends on the argument type.
 
 Now if we import ``abs`` as defined in the above library stub, we can


### PR DESCRIPTION
Some small typo fixes for `common_issues.rst`, `faq.rst` and `function_overloading.rst` files.