### PR TITLE
Fix typos

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -87,7 +87,7 @@ impact:
 
 The savings are rarely significant, but it could make a difference in
 a performance-critical loop or function. Function annotations, on the
-other hand, are only evaluated during the defintion of the function,
+other hand, are only evaluated during the definition of the function,
 not during every call. Constructing type objects in function
 signatures rarely has any noticeable performance impact.
 
@@ -108,7 +108,7 @@ Generic type variables can also be used to define generic functions:
        return seq[0]
 
 As with generic classes, the type variable can be replaced with any
-type. That means first can we used with any sequence type, and the
+type. That means ``first`` can be used with any sequence type, and the
 return type is derived from the sequence item type. For example:
 
 .. code-block:: python

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -5,7 +5,7 @@ Mypy is a static type checker for Python. If you sprinkle your code
 with type annotations using the Python 3 function annotation syntax,
 mypy can type check you code and find common bugs. Mypy is a static
 analyzer, or a lint-like tool: type annotations are just hints and are
-not enforced when running you program.  You run your program with a
+not enforced when running your program. You run your program with a
 standard Python interpreter, and the annotations are treated basically
 as comments.
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -122,7 +122,7 @@ Class name forward references
 *****************************
 
 Python does not allow references to a class object before the class is
-defined. Thus this code is does not work as expected:
+defined. Thus this code does not work as expected:
 
 .. code-block:: python
 
@@ -147,7 +147,7 @@ Of course, instead of using a string literal type, you could move the
 function definition after the class definition. This is not always
 desirable or even possible, though.
 
-Any type can be entered as a string literal, and youn can combine
+Any type can be entered as a string literal, and you can combine
 string-literal types with non-string-literal types freely:
 
 .. code-block:: python

--- a/docs/source/type_inference_and_annotations.rst
+++ b/docs/source/type_inference_and_annotations.rst
@@ -127,7 +127,7 @@ type separately:
    n, s = Undefined(int), Undefined(str)  # Declare an integer and a string
    i, found = 0, False # type: int, bool
 
-When using the latter form, you can optinally use parentheses around
+When using the latter form, you can optionally use parentheses around
 the types, assignment targets and assigned expression:
 
 .. code-block:: python


### PR DESCRIPTION
Fixes typos in `generics.rst`, `introduction.rst`, `kinds_of_types.rst` and `type_inference_and_annotations.rst`.