### PR TITLE
Don't verify overrides for dynamically typed methods.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -444,7 +444,8 @@ class TypeChecker(NodeVisitor[Type]):
         """Type check a function definition."""
         self.check_func_item(defn, name=defn.name())
         if defn.info:
-            self.check_method_override(defn)
+            if not defn.is_dynamic():
+                self.check_method_override(defn)
             self.check_inplace_operator_method(defn)
         if defn.original_def:
             if not is_same_type(self.function_type(defn),
@@ -465,7 +466,7 @@ class TypeChecker(NodeVisitor[Type]):
             fdef = defn
 
         self.function_stack.append(defn)
-        self.dynamic_funcs.append(defn.type is None and not type_override)
+        self.dynamic_funcs.append(defn.is_dynamic() and not type_override)
 
         if fdef:
             self.errors.push_function(fdef.name())

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -298,6 +298,9 @@ class FuncItem(FuncBase):
                 res.append(None)
         return res
 
+    def is_dynamic(self):
+        return self.type is None
+
 
 class FuncDef(FuncItem):
     """Function definition.

--- a/mypy/test/data/check-abstract.test
+++ b/mypy/test/data/check-abstract.test
@@ -293,10 +293,23 @@ class I(metaclass=ABCMeta):
     def g(self, x): pass
 class A(I):
     def f(self, x): pass
-    def g(self, x, y): pass \
+    def g(self, x, y) -> None: pass \
         # E: Signature of "g" incompatible with supertype "I"
 [out]
 main: In class "A":
+
+[case testAbstractClassWithAllDynamicTypes2]
+from abc import abstractmethod, ABCMeta
+import typing
+class I(metaclass=ABCMeta):
+    @abstractmethod
+    def f(self, x): pass
+    @abstractmethod
+    def g(self, x): pass
+class A(I):
+    def f(self, x): pass
+    def g(self, x, y): pass
+[out]
 
 [case testAbstractClassWithImplementationUsingDynamicTypes]
 from abc import abstractmethod, ABCMeta
@@ -308,10 +321,8 @@ class I(metaclass=ABCMeta):
     def g(self, x: int) -> None: pass
 class A(I):
     def f(self, x): pass
-    def g(self, x, y): pass \
-        # E: Signature of "g" incompatible with supertype "I"
+    def g(self, x, y): pass
 [out]
-main: In class "A":
 
 
 -- Special cases

--- a/mypy/test/data/check-dynamic-typing.test
+++ b/mypy/test/data/check-dynamic-typing.test
@@ -630,11 +630,9 @@ import typing
 class B:
     def f(self, x: A) -> None: pass
 class A(B):
-    def f(self, x, y): # Fail
+    def f(self, x, y): # dynamic function not type checked
         x()
 [out]
-main: In class "A":
-main, line 5: Signature of "f" incompatible with supertype "B"
 
 [case testInvalidOverrideArgumentCountWithImplicitSignature2]
 import typing
@@ -643,5 +641,15 @@ class B:
 class A(B):
     def f(self, x: 'A') -> None: # E: Signature of "f" incompatible with supertype "B"
         pass
+[out]
+main: In class "A":
+
+[case testInvalidOverrideArgumentCountWithImplicitSignature3]
+import typing
+class B:
+    def f(self, x: A) -> None: pass
+class A(B):
+    def f(self, x, y) -> None: # E: Signature of "f" incompatible with supertype "B"
+        x()
 [out]
 main: In class "A":


### PR DESCRIPTION
Fixes #620.