### PR TITLE
Support for no_type_check decorator

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -18,7 +18,8 @@ from mypy.nodes import (
     Decorator, SetExpr, PassStmt, TypeVarExpr, UndefinedExpr, PrintStmt,
     LITERAL_TYPE, BreakStmt, ContinueStmt, ComparisonExpr, StarExpr,
     YieldFromExpr, YieldFromStmt, NamedTupleExpr, SetComprehension,
-    DictionaryComprehension, ComplexExpr, EllipsisNode, TypeAliasExpr
+    DictionaryComprehension, ComplexExpr, EllipsisNode, TypeAliasExpr,
+    RefExpr
 )
 from mypy.nodes import function_type, method_type, method_type_with_fallback
 from mypy import nodes
@@ -1659,11 +1660,10 @@ class TypeChecker(NodeVisitor[Type]):
             return None
 
     def visit_decorator(self, e: Decorator) -> Type:
-
         for d in e.decorators:
-            if isinstance(d, NameExpr):
-                if d.name == 'no_type_check' or d.name == 'typing.no_type_check':
-                    return NoneTyp
+            if isinstance(d, RefExpr):
+                if d.fullname == 'typing.no_type_check':
+                    return NoneTyp()
 
         e.func.accept(self)
         sig = self.function_type(e.func)  # type: Type

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1659,6 +1659,12 @@ class TypeChecker(NodeVisitor[Type]):
             return None
 
     def visit_decorator(self, e: Decorator) -> Type:
+
+        for d in e.decorators:
+            if isinstance(d, NameExpr):
+                if d.name == 'no_type_check':
+                    return NoneTyp
+
         e.func.accept(self)
         sig = self.function_type(e.func)  # type: Type
         # Process decorators from the inside out.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1662,7 +1662,7 @@ class TypeChecker(NodeVisitor[Type]):
 
         for d in e.decorators:
             if isinstance(d, NameExpr):
-                if d.name == 'no_type_check':
+                if d.name == 'no_type_check' or d.name == 'typing.no_type_check':
                     return NoneTyp
 
         e.func.accept(self)

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -314,7 +314,8 @@ class Parser:
         while self.current_str() == '@':
             self.expect('@')
             d_exp = self.parse_expression()
-            if isinstance(d_exp, NameExpr) and d_exp.name == 'no_type_check':
+            if isinstance(d_exp, NameExpr) and (d_exp.name == 'no_type_check' or
+                                                d_exp.name == 'typing.no_type_check'):
                 no_type_checks = True
             decorators.append(d_exp)
             self.expect_break()

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -310,12 +310,16 @@ class Parser:
 
     def parse_decorated_function_or_class(self) -> Node:
         decorators = []  # type: List[Node]
+        no_type_checks = False
         while self.current_str() == '@':
             self.expect('@')
-            decorators.append(self.parse_expression())
+            d_exp = self.parse_expression()
+            if isinstance(d_exp, NameExpr) and d_exp.name == 'no_type_check':
+                no_type_checks = True
+            decorators.append(d_exp)
             self.expect_break()
         if self.current_str() != 'class':
-            func = self.parse_function()
+            func = self.parse_function(no_type_checks)
             func.is_decorated = True
             var = Var(func.name())
             # Types of decorated functions must always be inferred.
@@ -328,13 +332,13 @@ class Parser:
             cls.decorators = decorators
             return cls
 
-    def parse_function(self) -> FuncDef:
+    def parse_function(self, no_type_checks: bool=False) -> FuncDef:
         def_tok = self.expect('def')
         is_method = self.is_class_body
         self.is_class_body = False
         try:
             (name, args, init, kinds,
-             typ, is_error) = self.parse_function_header()
+             typ, is_error) = self.parse_function_header(no_type_checks)
 
             body, comment_type = self.parse_block(allow_type=True)
             if comment_type:
@@ -394,8 +398,8 @@ class Parser:
                     "Inconsistent use of '{}' in function "
                     "signature".format(token), line)
 
-    def parse_function_header(self) -> Tuple[str, List[Var], List[Node],
-                                             List[int], CallableType, bool]:
+    def parse_function_header(self, no_type_checks: bool=False) -> Tuple[str, List[Var], List[Node],
+                                                                         List[int], CallableType, bool]:
         """Parse function header (a name followed by arguments)
 
         Returns a 7-tuple with the following items:
@@ -415,7 +419,7 @@ class Parser:
 
             self.errors.push_function(name)
 
-            (args, init, kinds, typ) = self.parse_args()
+            (args, init, kinds, typ) = self.parse_args(no_type_checks)
         except ParseError:
             if not isinstance(self.current(), Break):
                 self.ind -= 1  # Kludge: go back to the Break token
@@ -426,7 +430,7 @@ class Parser:
 
         return (name, args, init, kinds, typ, False)
 
-    def parse_args(self) -> Tuple[List[Var], List[Node], List[int], CallableType]:
+    def parse_args(self, no_type_checks: bool=False) -> Tuple[List[Var], List[Node], List[int], CallableType]:
         """Parse a function signature (...) [-> t]."""
         lparen = self.expect('(')
 
@@ -434,13 +438,17 @@ class Parser:
         (args, init, kinds,
          has_inits, arg_names,
          commas, asterisk,
-         assigns, arg_types) = self.parse_arg_list()
+         assigns, arg_types) = self.parse_arg_list(no_type_checks=no_type_checks)
 
         self.expect(')')
 
         if self.current_str() == '->':
             self.skip()
-            ret_type = self.parse_type()
+            if no_type_checks:
+                self.parse_expression()
+                ret_type = None
+            else:
+                ret_type = self.parse_type()
         else:
             ret_type = None
 
@@ -466,7 +474,7 @@ class Parser:
             return None
 
     def parse_arg_list(
-        self, allow_signature: bool = True) -> Tuple[List[Var], List[Node],
+        self, allow_signature: bool = True, no_type_checks: bool=False) -> Tuple[List[Var], List[Node],
                                                      List[int], bool,
                                                      List[Token], List[Token],
                                                      List[Token], List[Token],
@@ -517,13 +525,23 @@ class Parser:
                         kinds.append(nodes.ARG_STAR2)
                     else:
                         kinds.append(nodes.ARG_STAR)
-                    arg_types.append(self.parse_arg_type(allow_signature))
+
+                    if no_type_checks:
+                        self.parse_parameter_annotation()
+                        arg_types.append(None)
+                    else:
+                        arg_types.append(self.parse_arg_type(allow_signature))
                     require_named = True
                 else:
                     name = self.expect_type(Name)
                     arg_names.append(name)
                     args.append(Var(name.string))
-                    arg_types.append(self.parse_arg_type(allow_signature))
+
+                    if no_type_checks:
+                        self.parse_parameter_annotation()
+                        arg_types.append(None)
+                    else:
+                        arg_types.append(self.parse_arg_type(allow_signature))
 
                     if self.current_str() == '=':
                         assigns.append(self.expect('='))
@@ -548,6 +566,11 @@ class Parser:
 
         return (args, init, kinds, has_inits, arg_names, commas, asterisk,
                 assigns, arg_types)
+
+    def parse_parameter_annotation(self) -> Node:
+        if self.current_str() == ':':
+            self.skip()
+            return self.parse_expression(precedence[','])
 
     def parse_arg_type(self, allow_signature: bool) -> Type:
         if self.current_str() == ':' and allow_signature:

--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -560,11 +560,22 @@ def dec2(f: Callable[[Any, Any], None]) -> Callable[[Any], None]: pass
 def f(x, y): pass
 
 
-[case testDecoratorThatSwitchesTypeWithMethod]
+[case testNoTypeCheckDecoratorOnMethod1]
 from typing import no_type_check
 
 @no_type_check
 def foo(x: 'bar', y: {'x': 4}) -> 42:
+    1 + 'x'
+
+[case testNoTypeCheckDecoratorOnMethod2]
+import typing
+
+@typing.no_type_check
+def foo(x: 's', y: {'x': 4}) -> 42:
+    1 + 'x'
+
+@typing.no_type_check
+def bar() -> None:
     1 + 'x'
 
 

--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -560,6 +560,16 @@ def dec2(f: Callable[[Any, Any], None]) -> Callable[[Any], None]: pass
 def f(x, y): pass
 
 
+[case testDecoratorThatSwitchesTypeWithMethod]
+from typing import no_type_checks
+
+@no_type_check
+def foo(x: 'bar', y: {'x': 4}) -> 42:
+    1 + 'x'
+[out]
+x
+
+
 -- Conditional function definition
 -- -------------------------------
 

--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -561,13 +561,11 @@ def f(x, y): pass
 
 
 [case testDecoratorThatSwitchesTypeWithMethod]
-from typing import no_type_checks
+from typing import no_type_check
 
 @no_type_check
 def foo(x: 'bar', y: {'x': 4}) -> 42:
     1 + 'x'
-[out]
-x
 
 
 -- Conditional function definition

--- a/mypy/test/data/lib-stub/typing.py
+++ b/mypy/test/data/lib-stub/typing.py
@@ -35,3 +35,6 @@ class Iterator(Iterable[T], Generic[T]):
 class Sequence(Generic[T]):
     @abstractmethod
     def __getitem__(self, n: Any) -> T: pass
+
+def no_type_check(func):
+    return func

--- a/mypy/test/data/lib-stub/typing.py
+++ b/mypy/test/data/lib-stub/typing.py
@@ -16,6 +16,7 @@ Callable = object()
 builtinclass = object()
 _promote = object()
 NamedTuple = object()
+no_type_check = object()
 
 # Type aliases.
 List = object()
@@ -35,6 +36,3 @@ class Iterator(Iterable[T], Generic[T]):
 class Sequence(Generic[T]):
     @abstractmethod
     def __getitem__(self, n: Any) -> T: pass
-
-def no_type_check(func):
-    return func


### PR DESCRIPTION
Implements #557.

~~I've renamed the `no_type_check` decorator to `no_type_checks`.~~

Currently the typexport-basic tests fails because the `no_type_check` decorator I added to the typing.py stub shows up in the output of all tests.