### PR TITLE
Fix for issue #286

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -379,6 +379,7 @@ class MessageBuilder:
         msg = ''
         if callee.name == '<list>':
             name = callee.name[1:-1]
+            n -= 1
             msg = '{} item {} has incompatible type {}'.format(
                 name[0].upper() + name[1:], n, self.format_simple(arg_type))
         elif callee.name == '<list-comprehension>':

--- a/mypy/test/data/check-expressions.test
+++ b/mypy/test/data/check-expressions.test
@@ -1201,7 +1201,7 @@ y = '' # E: Incompatible types in assignment (expression has type "str", variabl
 import typing
 x = [1] if None else []
 x = [1]
-x = ['x'] # E: List item 1 has incompatible type "str"
+x = ['x'] # E: List item 0 has incompatible type "str"
 [builtins fixtures/list.py]
 
 

--- a/mypy/test/data/check-generics.test
+++ b/mypy/test/data/check-generics.test
@@ -580,7 +580,7 @@ def f(a: List[A]) -> A: pass
 def f(a: B) -> B: pass
 
 b = f([a]) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-a = f([b]) # E: List item 1 has incompatible type "B"
+a = f([b]) # E: List item 0 has incompatible type "B"
 a = f(b)   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 a = f([a])

--- a/mypy/test/data/check-inference-context.test
+++ b/mypy/test/data/check-inference-context.test
@@ -354,8 +354,8 @@ ao = Undefined # type: List[object]
 a = Undefined # type: A
 b = Undefined # type: B
 
-aa = [b] # E: List item 1 has incompatible type "B"
-ab = [a] # E: List item 1 has incompatible type "A"
+aa = [b] # E: List item 0 has incompatible type "B"
+ab = [a] # E: List item 0 has incompatible type "A"
 
 aa = [a]
 ab = [b]
@@ -375,8 +375,8 @@ ao = Undefined # type: List[object]
 a = Undefined # type: A
 b = Undefined # type: B
 
-ab = [b, a] # E: List item 2 has incompatible type "A"
-ab = [a, b] # E: List item 1 has incompatible type "A"
+ab = [b, a] # E: List item 1 has incompatible type "A"
+ab = [a, b] # E: List item 0 has incompatible type "A"
 
 aa = [a, b, a]
 ao = [a, b]
@@ -391,7 +391,7 @@ def f() -> None:
     a = []     # E: Need type annotation for variable
     b = [None]  # E: Need type annotation for variable
     c = [B()]
-    c = [object()] # E: List item 1 has incompatible type "object"
+    c = [object()] # E: List item 0 has incompatible type "object"
     c = [B()]
 class B: pass
 [builtins fixtures/list.py]
@@ -406,8 +406,8 @@ ab = Undefined # type: List[B]
 b = Undefined # type: B
 o = Undefined # type: object
 
-aao = [[o], ab] # E: List item 2 has incompatible type List[B]
-aab = [[], [o]] # E: List item 1 has incompatible type "object"
+aao = [[o], ab] # E: List item 1 has incompatible type List[B]
+aab = [[], [o]] # E: List item 0 has incompatible type "object"
 
 aao = [[None], [b], [], [o]]
 aab = [[None], [b], []]
@@ -533,7 +533,7 @@ class set(Generic[t]):
     def __init__(self, iterable: Iterable[t]) -> None: pass
 b = bool()
 l = set([b])
-l = set([object()]) # E: List item 1 has incompatible type "object"
+l = set([object()]) # E: List item 0 has incompatible type "object"
 [builtins fixtures/for.py]
 
 
@@ -568,7 +568,7 @@ class B:
 from typing import Undefined, List, Callable
 f = Undefined # type: Callable[[], List[A]]
 f = lambda: []
-f = lambda: [B()]  # E: List item 1 has incompatible type "B"
+f = lambda: [B()]  # E: List item 0 has incompatible type "B"
 class A: pass
 class B: pass
 [builtins fixtures/list.py]
@@ -694,14 +694,14 @@ class A:
 a = A()
 a.x = []
 a.x = [1]
-a.x = [''] # E: List item 1 has incompatible type "str"
+a.x = [''] # E: List item 0 has incompatible type "str"
 [builtins fixtures/list.py]
 
 [case testListMultiplyInContext]
 from typing import Undefined, List
 a = Undefined(List[int])
 a = [None] * 3
-a = [''] * 3 # E: List item 1 has incompatible type "str"
+a = [''] * 3 # E: List item 0 has incompatible type "str"
 [builtins fixtures/list.py]
 
 [case testUnionTypeContext]

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -625,7 +625,7 @@ main: In function "f":
 from typing import List, Iterator
 def f() -> 'Iterator[List[int]]':
     yield []
-    yield [object()] # E: List item 1 has incompatible type "object"
+    yield [object()] # E: List item 0 has incompatible type "object"
 [builtins fixtures/for.py]
 [out]
 main: In function "f":

--- a/mypy/test/data/check-tuples.test
+++ b/mypy/test/data/check-tuples.test
@@ -447,8 +447,8 @@ na = a  # E
 class A: pass
 [builtins fixtures/list.py]
 [out]
+main, line 6: List item 0 has incompatible type "A"
 main, line 6: List item 1 has incompatible type "A"
-main, line 6: List item 2 has incompatible type "A"
 main, line 9: Incompatible types in assignment (expression has type "A", variable has type List[A])
 
 [case testAssignmentToStarFromTupleInference]

--- a/mypy/test/data/check-type-aliases.test
+++ b/mypy/test/data/check-type-aliases.test
@@ -32,7 +32,7 @@ from typing import List, Undefined
 A = List[int]
 def f(x: A) -> None: pass
 f([1])
-f(['x']) # E: List item 1 has incompatible type "str"
+f(['x']) # E: List item 0 has incompatible type "str"
 [builtins fixtures/list.py]
 [out]
 


### PR DESCRIPTION
Hi, would something like this be acceptable as a fix for issue #286?

This is what I tested with:
```
from typing import List, Tuple
foo1 = [('y', 1),
       ]  # type: List[Tuple[str, str]]

foo2 = [('x', 'x'),
       ('y', 1),
       ]  # type: List[Tuple[str, str]]

foo3 = [('x', 'x'),
       ('y', 'y'),
       ('y', 1),
       ]  # type: List[Tuple[str, str]]
```
These are the results:
```
/dev/shm/y.py, line 2: List item 0 has incompatible type "Tuple[str, int]"
/dev/shm/y.py, line 5: List item 1 has incompatible type "Tuple[str, int]"
/dev/shm/y.py, line 9: List item 2 has incompatible type "Tuple[str, int]"
```
This also breaks some thirteen test cases, but as far as I can tell those are all expected to be broken with this change. I can fix them if this is acceptable, I'm just not sure if I'm missing something here, the fix seems way too simple. :)