### PR TITLE
Add stubs for __qualname__

### DIFF
--- a/stubs/3.2/builtins.py
+++ b/stubs/3.2/builtins.py
@@ -39,6 +39,7 @@ class object:
 
 class type:
     __name__ = ''
+    __qualname__ = ''
     __module__ = ''
     __dict__ = Undefined # type: Dict[str, Any]
 
@@ -428,6 +429,7 @@ class tuple(Sequence[Any]):
 class function:
     # TODO not defined in builtins!
     __name__ = ''
+    __qualname__ = ''
     __module__ = ''
     __code__ = Undefined(Any)
 


### PR DESCRIPTION
The mypy stubs are missing the `__qualname__` attribute which was introduced in python 3.3 with [pep 3155][1].

I'm not sure what the strategy is regarding supporting builtins for versions 3.3+ in mypy (it's not entirely clear in the [wiki][2] - it comes across as though 3.3+ builtins should also be included in 3.2, it's also not possible to provide a stub with the same name in 3.2/ and 3.3/ and have mypy automatically choose the right one), so I added the attributes to the builtins in 3.2.

Additionally, I wasn't sure exactly how exactly mypy models the python builtins: the `__qualname__` attribute is valid for the python `descrobject`, `methodobject`, `classobject`, `typeobject` and `_pickle` entities. I assume that the `function` models the `methodobject` but wasn't able to find references to `descrobject` or `classobject`.

Let me know if you'd like me to make any changes and re-submit.

[1]: https://www.python.org/dev/peps/pep-3155/
[2]: http://www.mypy-lang.org/wiki/CreatingStubsForPythonModules