### PR TITLE
Remove some uses of overload

### DIFF
--- a/stubs/3.2/fnmatch.py
+++ b/stubs/3.2/fnmatch.py
@@ -3,20 +3,9 @@
 # Based on http://docs.python.org/3.2/library/fnmatch.html and
 # python-lib/fnmatch.py
 
-from typing import overload, Iterable, List
+from typing import Iterable, List, AnyStr
 
-@overload
-def fnmatch(name: str, pat: str) -> bool: pass
-@overload
-def fnmatch(name: bytes, pat: bytes) -> bool: pass
-
-@overload
-def fnmatchcase(name: str, pat: str) -> bool: pass
-@overload
-def fnmatchcase(name: bytes, pat: bytes) -> bool: pass
-
-@overload
-def filter(names: Iterable[str], pat: str) -> List[str]: pass
-@overload
-def filter(names: Iterable[bytes], pat: bytes) -> List[bytes]: pass
+def fnmatch(name: AnyStr, pat: AnyStr) -> bool: pass
+def fnmatchcase(name: AnyStr, pat: AnyStr) -> bool: pass
+def filter(names: Iterable[AnyStr], pat: AnyStr) -> List[AnyStr]: pass
 def translate(pat: str) -> str: pass

--- a/stubs/3.2/glob.py
+++ b/stubs/3.2/glob.py
@@ -2,13 +2,7 @@
 
 # Based on http://docs.python.org/3.2/library/glob.html
 
-from typing import overload, List, Iterator
+from typing import List, Iterator, AnyStr
 
-@overload
-def glob(pathname: str) -> List[str]: pass
-@overload
-def glob(pathname: bytes) -> List[bytes]: pass
-@overload
-def iglob(pathname: str) -> Iterator[str]: pass
-@overload
-def iglob(pathname: bytes) -> Iterator[bytes]: pass
+def glob(pathname: AnyStr) -> List[AnyStr]: pass
+def iglob(pathname: AnyStr) -> Iterator[AnyStr]: pass

--- a/stubs/3.2/posixpath.py
+++ b/stubs/3.2/posixpath.py
@@ -3,7 +3,7 @@
 
 # based on http://docs.python.org/3.2/library/os.path.html
 
-from typing import Any, List, Tuple, IO, overload
+from typing import Any, List, Tuple, IO
 
 # ----- os.path variables -----
 supports_unicode_filenames = False

--- a/stubs/3.2/re.py
+++ b/stubs/3.2/re.py
@@ -6,7 +6,7 @@
 # and http://hg.python.org/cpython/file/618ea5612e83/Lib/re.py
 
 from typing import (
-    Undefined, List, Iterator, overload, Callable, Tuple, Sequence, Dict,
+    Undefined, List, Iterator, Callable, Tuple, Sequence, Dict, Union,
     Generic, AnyStr, Match, Pattern
 )
 
@@ -46,20 +46,12 @@ def findall(pattern: AnyStr, string: AnyStr,
 def finditer(pattern: AnyStr, string: AnyStr,
              flags: int = 0) -> Iterator[Match[AnyStr]]: pass
 
-@overload
-def sub(pattern: AnyStr, repl: AnyStr, string: AnyStr, count: int = 0,
-        flags: int = 0) -> AnyStr: pass
-@overload
-def sub(pattern: AnyStr, repl: Callable[[Match[AnyStr]], AnyStr],
+def sub(pattern: AnyStr, repl: Union[AnyStr, Callable[[Match[AnyStr]], AnyStr]],
         string: AnyStr, count: int = 0, flags: int = 0) -> AnyStr: pass
 
-@overload
-def subn(pattern: AnyStr, repl: AnyStr, string: AnyStr, count: int = 0,
-         flags: int = 0) -> Tuple[AnyStr, int]: pass
-@overload
-def subn(pattern: AnyStr, repl: Callable[[Match[AnyStr]], AnyStr],
-         string: AnyStr, count: int = 0,
-         flags: int = 0) -> Tuple[AnyStr, int]: pass
+def subn(pattern: AnyStr, repl: Union[AnyStr, Callable[[Match[AnyStr]], AnyStr]],
+         string: AnyStr, count: int = 0, flags: int = 0) -> Tuple[AnyStr, int]:
+    pass
 
 def escape(string: AnyStr) -> AnyStr: pass
 

--- a/stubs/3.2/shutil.py
+++ b/stubs/3.2/shutil.py
@@ -6,9 +6,7 @@
 # sometimes they only work partially (broken exception messages), and the test
 # cases don't use them.
 
-from typing import (
-    overload, List, Iterable, Callable, Any, Tuple, Sequence, IO, AnyStr
-)
+from typing import List, Iterable, Callable, Any, Tuple, Sequence, IO, AnyStr
 
 def copyfileobj(fsrc: IO[AnyStr], fdst: IO[AnyStr],
                 length: int = None) -> None: pass

--- a/stubs/3.2/struct.py
+++ b/stubs/3.2/struct.py
@@ -2,46 +2,26 @@
 
 # Based on http://docs.python.org/3.2/library/struct.html
 
-from typing import overload, Any, Undefined
+from typing import overload, Any, Undefined, AnyStr
 
 class error(Exception): pass
 
-@overload
-def pack(fmt: str, *v: Any) -> bytes: pass
-@overload
-def pack(fmt: bytes, *v: Any) -> bytes: pass
-
-@overload
-def pack_into(fmt: str, buffer: Any, offset: int, *v: Any) -> None: pass
+def pack(fmt: AnyStr, *v: Any) -> bytes: pass
 # TODO buffer type
-@overload
-def pack_into(fmt: bytes, buffer: Any, offset: int, *v: Any) -> None: pass
+def pack_into(fmt: AnyStr, buffer: Any, offset: int, *v: Any) -> None: pass
 
 # TODO return type should be tuple
 # TODO buffer type
-@overload
-def unpack(fmt: str, buffer: Any) -> Any: pass
-@overload
-def unpack(fmt: bytes, buffer: Any) -> Any: pass
+def unpack(fmt: AnyStr, buffer: Any) -> Any: pass
+def unpack_from(fmt: AnyStr, buffer: Any, offset: int = 0) -> Any: pass
 
-@overload
-def unpack_from(fmt: str, buffer: Any) -> Any: pass
-@overload
-def unpack_from(fmt: bytes, buffer: Any, offset: int = 0) -> Any: pass
-
-@overload
-def calcsize(fmt: str) -> int: pass
-@overload
-def calcsize(fmt: bytes) -> int: pass
+def calcsize(fmt: AnyStr) -> int: pass
 
 class Struct:
     format = b''
     size = 0
 
-    @overload
-    def __init__(self, format: str) -> None: pass
-    @overload
-    def __init__(self, format: bytes) -> None: pass
+    def __init__(self, format: AnyStr) -> None: pass
 
     def pack(self, *v: Any) -> bytes: pass
     # TODO buffer type

--- a/stubs/3.2/warnings.py
+++ b/stubs/3.2/warnings.py
@@ -2,22 +2,13 @@
 
 # Based on http://docs.python.org/3.2/library/warnings.html
 
-from typing import overload, Any, List, TextIO
+from typing import Any, List, TextIO, Union
 
-@overload
-def warn(message: str, category: type = None,
-         stacklevel: int = 1) -> None: pass
-@overload
-def warn(message: Warning, category: type = None,
+def warn(message: Union[str, Warning], category: type = None,
          stacklevel: int = 1) -> None: pass
 
-@overload
-def warn_explicit(message: str, category: type, filename: str, lineno: int,
-                  module: str = None, registry: Any = None,
-                  module_globals: Any = None) -> None: pass
-@overload
-def warn_explicit(message: Warning, category: type, filename: str, lineno: int,
-                  module: str = None, registry: Any = None,
+def warn_explicit(message: Union[str, Warning], category: type, filename: str,
+                  lineno: int, module: str = None, registry: Any = None,
                   module_globals: Any = None) -> None: pass
 
 # logging modifies showwarning => make it a variable.


### PR DESCRIPTION
This fixes #432 and removes some other uses of `@overload` that were pretty simple.