### PR TITLE
No type check fix

### DIFF
--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -578,7 +578,7 @@ def foo(x: 's', y: {'x': 4}) -> 42:
 def bar() -> None:
     1 + 'x'
 
-[case testCallingNoTypeCheckFunction]
+[case testCallingNoTypeCheckFunction2]
 import typing
 
 @typing.no_type_check
@@ -587,6 +587,23 @@ def foo(x: {1:2}) -> [1]:
 
 foo()
 foo(1, 'b')
+
+[case testCallingNoTypeCheckFunction2]
+import typing
+
+def f() -> None:
+    foo()
+
+@typing.no_type_check
+def foo(x: {1:2}) -> [1]:
+    1 + 'x'
+
+[case testNoTypeCheckDecoratorSemanticError]
+import typing
+
+@typing.no_type_check
+def foo(x: {1:2}) -> [1]:
+    x = y
 
 
 -- Conditional function definition


### PR DESCRIPTION
Fixes #663 and now also ignores semantic errors in function decorated with `no_type_check`.