### PR TITLE
Use standard `file:line: level: message` format

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -176,9 +176,16 @@ class Errors:
             s = ''
             if file is not None:
                 if line is not None and line >= 0:
-                    s = '{}, line {}: {}'.format(file, line, message)
+                    s = '{}:{}: error: {}'.format(file, line, message)
                 else:
-                    s = '{}: {}'.format(file, message)
+                    # Currently, `message` has one of the following forms:
+                    #   'In class "X"'
+                    #   'In function "X"'
+                    #   'In member "X" of class "Y"'
+                    #   'At top level'
+                    # all of which are notes, not errors. This will need
+                    # changing if their line numbers get remembered.
+                    s = '{}: note: {}'.format(file, message)
             else:
                 s = message
             a.append(s)
@@ -206,9 +213,9 @@ class Errors:
                 i = last
                 while i >= 0:
                     path, line = e.import_ctx[i]
-                    fmt = 'In module imported in {}, line {}'
+                    fmt = '{}:{}: note: In module imported here'
                     if i < last:
-                        fmt = '                   in {}, line {}'
+                        fmt = '{}:{}: note: ... from here'
                     if i > 0:
                         fmt += ','
                     else:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -290,10 +290,10 @@ def expand_includes(a: List[str], base_path: str) -> List[str]:
 def expand_errors(input, output, fnam):
     """Transform comments such as '# E: message' in input.
 
-    The result is lines like 'fnam, line N: message'.
+    The result is lines like 'fnam:line: error: message'.
     """
 
     for i in range(len(input)):
         m = re.search('# E: (.*)$', input[i])
         if m:
-            output.append('{}, line {}: {}'.format(fnam, i + 1, m.group(1)))
+            output.append('{}:{}: error: {}'.format(fnam, i + 1, m.group(1)))

--- a/mypy/test/data/check-abstract.test
+++ b/mypy/test/data/check-abstract.test
@@ -176,7 +176,7 @@ class B(A):
         pass
     def g(self, x: int) -> int: pass
 [out]
-main: In class "B":
+main: note: In class "B":
 
 [case testImplementingAbstractMethodWithMultipleBaseClasses]
 from abc import abstractmethod, ABCMeta
@@ -194,7 +194,7 @@ class A(I, J):
         # E: Return type of "g" incompatible with supertype "J"
     def h(self) -> int: pass # Not related to any base class
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testImplementingAbstractMethodWithExtension]
 from abc import abstractmethod, ABCMeta
@@ -207,7 +207,7 @@ class A(I):
     def f(self, x: str) -> int: pass \
         # E: Argument 1 of "f" incompatible with supertype "J"
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testInvalidOverridingAbstractMethod]
 from abc import abstractmethod, ABCMeta
@@ -219,7 +219,7 @@ class I(J):
     @abstractmethod
     def f(self, x: 'I') -> None: pass # E: Argument 1 of "f" incompatible with supertype "J"
 [out]
-main: In class "I":
+main: note: In class "I":
 
 [case testAbstractClassCoAndContraVariance]
 from abc import abstractmethod, ABCMeta
@@ -239,9 +239,9 @@ class A(I):
     def g(self, a: 'A') -> 'A':
         pass
 [out]
-main: In class "A":
-main, line 11: Argument 1 of "h" incompatible with supertype "I"
-main, line 11: Return type of "h" incompatible with supertype "I"
+main: note: In class "A":
+main:11: error: Argument 1 of "h" incompatible with supertype "I"
+main:11: error: Return type of "h" incompatible with supertype "I"
 
 
 -- Accessing abstract members
@@ -296,7 +296,7 @@ class A(I):
     def g(self, x, y) -> None: pass \
         # E: Signature of "g" incompatible with supertype "I"
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testAbstractClassWithAllDynamicTypes2]
 from abc import abstractmethod, ABCMeta
@@ -450,7 +450,7 @@ class A(metaclass=ABCMeta):
   @overload
   def f(self, x: str) -> str: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testOverloadedAbstractMethodVariantMissingDecorator1]
 from abc import abstractmethod, ABCMeta
@@ -464,7 +464,7 @@ class A(metaclass=ABCMeta):
   @overload
   def f(self, x: str) -> str: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testMultipleInheritanceAndAbstractMethod]
 import typing
@@ -486,8 +486,8 @@ class B(metaclass=ABCMeta):
   def f(self, x: int) -> None: pass
 class C(A, B): pass
 [out]
-main: In class "C":
-main, line 8: Definition of "f" in base class "A" is incompatible with definition in base class "B"
+main: note: In class "C":
+main:8: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 
 [case testCallAbstractMethodBeforeDefinition]
 import typing
@@ -498,7 +498,7 @@ class A(metaclass=ABCMeta):
     @abstractmethod
     def g(self, x: str) -> None: pass
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 [case testAbstractOperatorMethods1]
 import typing

--- a/mypy/test/data/check-basic.test
+++ b/mypy/test/data/check-basic.test
@@ -10,7 +10,7 @@ a = b # Fail
 class A: pass
 class B: pass
 [out]
-main, line 5: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testConstructionAndAssignment]
 
@@ -22,7 +22,7 @@ class A:
 class B:
     def __init__(self): pass
 [out]
-main, line 4: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testInheritInitFromObject]
 
@@ -32,7 +32,7 @@ x = B()
 class A(object): pass
 class B(object): pass
 [out]
-main, line 4: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testImplicitInheritInitFromObject]
 
@@ -49,7 +49,7 @@ class B: pass
 import typing
 object(object())
 [out]
-main, line 2: Too many arguments for "object"
+main:2: error: Too many arguments for "object"
 
 [case testVarDefWithInit]
 import typing
@@ -57,7 +57,7 @@ a = A() # type: A
 b = object() # type: A
 class A: pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "object", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "object", variable has type "A")
 
 [case testInheritanceBasedSubtyping]
 import typing
@@ -66,7 +66,7 @@ y = A() # type: B # Fail
 class A: pass
 class B(A): pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:3: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testDeclaredVariableInParentheses]
 
@@ -87,14 +87,14 @@ f(B()) # Fail
 class A: pass
 class B: pass
 [out]
-main, line 4: Argument 1 to "f" has incompatible type "B"; expected "A"
+main:4: error: Argument 1 to "f" has incompatible type "B"; expected "A"
 
 [case testNotCallable]
 import typing
 A()()
 class A: pass
 [out]
-main, line 2: "A" not callable
+main:2: error: "A" not callable
 
 [case testSubtypeArgument]
 import typing
@@ -105,7 +105,7 @@ f(B(), B())
 class A: pass
 class B(A): pass
 [out]
-main, line 3: Argument 2 to "f" has incompatible type "A"; expected "B"
+main:3: error: Argument 2 to "f" has incompatible type "A"; expected "B"
 
 [case testInvalidArgumentCount]
 import typing
@@ -113,8 +113,8 @@ def f(x, y) -> None: pass
 f(object())
 f(object(), object(), object())
 [out]
-main, line 3: Too few arguments for "f"
-main, line 4: Too many arguments for "f"
+main:3: error: Too few arguments for "f"
+main:4: error: Too many arguments for "f"
 
 
 -- Locals
@@ -131,8 +131,8 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
-main, line 6: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In function "f":
+main:6: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testLocalVariableScope]
 
@@ -145,8 +145,8 @@ def g() -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "g":
-main, line 7: Incompatible types in assignment (expression has type "A", variable has type "B")
+main: note: In function "g":
+main:7: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testFunctionArguments]
 import typing
@@ -157,8 +157,8 @@ def f(x: 'A', y: 'B') -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
-main, line 3: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In function "f":
+main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testLocalVariableInitialization]
 import typing
@@ -168,8 +168,8 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
-main, line 4: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In function "f":
+main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testVariableInitializationWithSubtype]
 import typing
@@ -178,7 +178,7 @@ y = A() # type: B # Fail
 class A: pass
 class B(A): pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:3: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 
 -- Misc
@@ -192,8 +192,8 @@ def f() -> 'A':
 class A: pass
 class B: pass
 [out]
-main: In function "f":
-main, line 3: Incompatible return value type: expected __main__.A, got __main__.B
+main: note: In function "f":
+main:3: error: Incompatible return value type: expected __main__.A, got __main__.B
 
 [case testTopLevelContextAndInvalidReturn]
 import typing
@@ -203,10 +203,10 @@ a = B() # type: A
 class A: pass
 class B: pass
 [out]
-main: In function "f":
-main, line 3: Incompatible return value type: expected __main__.A, got __main__.B
-main: At top level:
-main, line 4: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In function "f":
+main:3: error: Incompatible return value type: expected __main__.A, got __main__.B
+main: note: At top level:
+main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testModule__name__]
 import typing
@@ -249,11 +249,11 @@ a = A()
 class A: pass
 class B: pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "B", variable has type "A")
-main: In function "f":
-main, line 7: Incompatible types in assignment (expression has type "A", variable has type "B")
-main: At top level:
-main, line 9: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In function "f":
+main:7: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+main: note: At top level:
+main:9: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testGlobalDefinedInBlockWithType]
 
@@ -273,10 +273,10 @@ def f(x): # type: (int) -> str
     return 1
 f('')
 [out]
-main: In function "f":
-main, line 2: Incompatible return value type: expected builtins.str, got builtins.int
-main: At top level:
-main, line 3: Argument 1 to "f" has incompatible type "str"; expected "int"
+main: note: In function "f":
+main:2: error: Incompatible return value type: expected builtins.str, got builtins.int
+main: note: At top level:
+main:3: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testMethodSignatureAsComment]
 class A:
@@ -286,8 +286,8 @@ class A:
         return 1
 A().f('') # Fail
 [out]
-main: In member "f" of class "A":
-main, line 4: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
-main, line 5: Incompatible return value type: expected builtins.str, got builtins.int
-main: At top level:
-main, line 6: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+main: note: In member "f" of class "A":
+main:4: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+main:5: error: Incompatible return value type: expected builtins.str, got builtins.int
+main: note: At top level:
+main:6: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"

--- a/mypy/test/data/check-classes.test
+++ b/mypy/test/data/check-classes.test
@@ -18,8 +18,8 @@ class A:
 class B:
     def bar(self, x: 'B', y: A) -> None: pass
 [out]
-main, line 5: Argument 1 to "foo" of "A" has incompatible type "B"; expected "A"
-main, line 6: "A" has no attribute "bar"
+main:5: error: Argument 1 to "foo" of "A" has incompatible type "B"; expected "A"
+main:6: error: "A" has no attribute "bar"
 
 [case testMethodCallWithSubtype]
 
@@ -34,7 +34,7 @@ class A:
     def bar(self, x: 'B') -> None: pass
 class B(A): pass
 [out]
-main, line 5: Argument 1 to "bar" of "A" has incompatible type "A"; expected "B"
+main:5: error: Argument 1 to "bar" of "A" has incompatible type "A"; expected "B"
 
 [case testInheritingMethod]
 
@@ -46,7 +46,7 @@ class A:
     def foo(self, x: 'B') -> None: pass
 class B(A): pass
 [out]
-main, line 3: Argument 1 to "foo" of "A" has incompatible type "A"; expected "B"
+main:3: error: Argument 1 to "foo" of "A" has incompatible type "A"; expected "B"
 
 [case testMethodCallWithInvalidNumberOfArguments]
 
@@ -57,9 +57,9 @@ a.foo(object(), A())  # Fail
 class A:
     def foo(self, x: 'A') -> None: pass
 [out]
-main, line 3: Too few arguments for "foo" of "A"
-main, line 4: Too many arguments for "foo" of "A"
-main, line 4: Argument 1 to "foo" of "A" has incompatible type "object"; expected "A"
+main:3: error: Too few arguments for "foo" of "A"
+main:4: error: Too many arguments for "foo" of "A"
+main:4: error: Argument 1 to "foo" of "A" has incompatible type "object"; expected "A"
 
 [case testMethodBody]
 import typing
@@ -67,8 +67,8 @@ class A:
     def f(self) -> None:
         a = object() # type: A    # Fail
 [out]
-main: In member "f" of class "A":
-main, line 4: Incompatible types in assignment (expression has type "object", variable has type "A")
+main: note: In member "f" of class "A":
+main:4: error: Incompatible types in assignment (expression has type "object", variable has type "A")
 
 [case testMethodArguments]
 import typing
@@ -82,10 +82,10 @@ class A:
         a = b # Fail
 class B: pass
 [out]
-main: In member "f" of class "A":
-main, line 4: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 5: Incompatible types in assignment (expression has type "A", variable has type "B")
-main, line 9: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In member "f" of class "A":
+main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:9: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testReturnFromMethod]
 import typing
@@ -95,8 +95,8 @@ class A:
         return A()
 class B: pass
 [out]
-main: In member "f" of class "A":
-main, line 4: Incompatible return value type: expected __main__.A, got __main__.B
+main: note: In member "f" of class "A":
+main:4: error: Incompatible return value type: expected __main__.A, got __main__.B
 
 [case testSelfArgument]
 import typing
@@ -108,9 +108,9 @@ class A:
         self.f()
 class B: pass
 [out]
-main: In member "f" of class "A":
-main, line 4: Incompatible types in assignment (expression has type "A", variable has type "B")
-main, line 5: "A" has no attribute "g"
+main: note: In member "f" of class "A":
+main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:5: error: "A" has no attribute "g"
 
 [case testAssignToMethodViaInstance]
 import typing
@@ -134,8 +134,8 @@ a.y = object()
 a.x
 a.x = object()
 [out]
-main, line 6: "A" has no attribute "y"
-main, line 7: "A" has no attribute "y"
+main:6: error: "A" has no attribute "y"
+main:7: error: "A" has no attribute "y"
 
 [case testArgumentTypeInference]
 
@@ -152,9 +152,9 @@ b.a     # Fail
 a.a = a
 a.b = b
 [out]
-main, line 9: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 10: Incompatible types in assignment (expression has type "A", variable has type "B")
-main, line 11: "B" has no attribute "a"
+main:9: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:10: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:11: error: "B" has no attribute "a"
 
 [case testExplicitAttributeInBody]
 
@@ -164,7 +164,7 @@ a.x = A()
 class A:
   x = None # type: A
 [out]
-main, line 3: Incompatible types in assignment (expression has type "object", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "object", variable has type "A")
 
 [case testAttributeDefinedInNonInitMethod]
 import typing
@@ -188,7 +188,7 @@ class B(A):
     def f(self) -> None:
         self.x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
-main: In member "f" of class "B":
+main: note: In member "f" of class "B":
 
 [case testAssignmentToAttributeInMultipleMethods]
 import typing
@@ -200,10 +200,10 @@ class A:
     def __init__(self) -> None:
         self.x = '' # Fail
 [out]
-main: In member "g" of class "A":
-main, line 6: Incompatible types in assignment (expression has type "str", variable has type "int")
-main: In member "__init__" of class "A":
-main, line 8: Incompatible types in assignment (expression has type "str", variable has type "int")
+main: note: In member "g" of class "A":
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main: note: In member "__init__" of class "A":
+main:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 
 -- Method overriding
@@ -241,9 +241,9 @@ class B(A):
   def g(self, x: A, y: A) -> A: pass
   def h(self, x: A, y: 'B') -> object: pass  # Fail
 [out]
-main: In class "B":
-main, line 7: Argument 1 of "f" incompatible with supertype "A"
-main, line 9: Return type of "h" incompatible with supertype "A"
+main: note: In class "B":
+main:7: error: Argument 1 of "f" incompatible with supertype "A"
+main:9: error: Return type of "h" incompatible with supertype "A"
 
 [case testMethodOverridingWithIncompatibleArgumentCount]
 import typing
@@ -254,9 +254,9 @@ class B(A):
     def f(self, x: A, y: A) -> None: pass # Fail
     def g(self, x: A) -> A: pass # Fail
 [out]
-main: In class "B":
-main, line 6: Signature of "f" incompatible with supertype "A"
-main, line 7: Signature of "g" incompatible with supertype "A"
+main: note: In class "B":
+main:6: error: Signature of "f" incompatible with supertype "A"
+main:7: error: Signature of "g" incompatible with supertype "A"
 
 [case testMethodOverridingAcrossDeepInheritanceHierarchy1]
 import typing
@@ -267,8 +267,8 @@ class C(B): # with gap in implementations
     def f(self, x: 'C') -> None:  # Fail
         pass
 [out]
-main: In class "C":
-main, line 6: Argument 1 of "f" incompatible with supertype "A"
+main: note: In class "C":
+main:6: error: Argument 1 of "f" incompatible with supertype "A"
 
 [case testMethodOverridingAcrossDeepInheritanceHierarchy2]
 import typing
@@ -280,8 +280,8 @@ class C(B): # with multiple implementations
     def f(self) -> B:  # Fail
         pass
 [out]
-main: In class "C":
-main, line 7: Return type of "f" incompatible with supertype "B"
+main: note: In class "C":
+main:7: error: Return type of "f" incompatible with supertype "B"
 
 [case testMethodOverridingWithVoidReturnValue]
 import typing
@@ -292,9 +292,9 @@ class B(A):
     def f(self) -> A: pass  # Fail
     def g(self) -> None: pass  # Fail
 [out]
-main: In class "B":
-main, line 6: Return type of "f" incompatible with supertype "A"
-main, line 7: Return type of "g" incompatible with supertype "A"
+main: note: In class "B":
+main:6: error: Return type of "f" incompatible with supertype "A"
+main:7: error: Return type of "g" incompatible with supertype "A"
 
 
 -- Constructors
@@ -309,7 +309,7 @@ class A:
     def __init__(self) -> None: pass
 class B: pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:3: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testConstructor]
 import typing
@@ -320,8 +320,8 @@ class A:
     def __init__(self, x: 'B') -> None: pass
 class B: pass
 [out]
-main, line 3: Argument 1 to "A" has incompatible type "object"; expected "B"
-main, line 4: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:3: error: Argument 1 to "A" has incompatible type "object"; expected "B"
+main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testConstructorWithTwoArguments]
 import typing
@@ -332,7 +332,7 @@ class A:
 class B: pass
 class C(B): pass
 [out]
-main, line 2: Argument 2 to "A" has incompatible type "B"; expected "C"
+main:2: error: Argument 2 to "A" has incompatible type "B"; expected "C"
 
 [case testInheritedConstructor]
 import typing
@@ -344,7 +344,7 @@ class B(A): pass
 class C: pass
 class D: pass
 [out]
-main, line 3: Argument 1 to "B" has incompatible type "D"; expected "C"
+main:3: error: Argument 1 to "B" has incompatible type "D"; expected "C"
 
 [case testOverridingWithIncompatibleConstructor]
 import typing
@@ -358,24 +358,24 @@ class B(A):
     def __init__(self) -> None: pass
 class C: pass
 [out]
-main, line 2: Too few arguments for "A"
-main, line 3: Too many arguments for "B"
+main:2: error: Too few arguments for "A"
+main:3: error: Too many arguments for "B"
 
 [case testConstructorWithReturnValueType]
 import typing
 class A:
     def __init__(self) -> 'A': pass
 [out]
-main: In member "__init__" of class "A":
-main, line 3: The return type of "__init__" must be None
+main: note: In member "__init__" of class "A":
+main:3: error: The return type of "__init__" must be None
 
 [case testConstructorWithImplicitReturnValueType]
 import typing
 class A:
     def __init__(self, x: int): pass
 [out]
-main: In member "__init__" of class "A":
-main, line 3: The return type of "__init__" must be None
+main: note: In member "__init__" of class "A":
+main:3: error: The return type of "__init__" must be None
 
 [case testGlobalFunctionInitWithReturnType]
 import typing
@@ -385,7 +385,7 @@ def __init__() -> 'A': pass
 class A: pass
 class B: pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:3: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testAccessingInit]
 from typing import Any
@@ -412,10 +412,10 @@ class C(B): pass
 class D(C): pass
 class D2(C): pass
 [out]
-main, line 2: Incompatible types in assignment (expression has type "C", variable has type "D")
-main, line 3: Incompatible types in assignment (expression has type "B", variable has type "D")
-main, line 4: Incompatible types in assignment (expression has type "A", variable has type "D")
-main, line 5: Incompatible types in assignment (expression has type "D2", variable has type "D")
+main:2: error: Incompatible types in assignment (expression has type "C", variable has type "D")
+main:3: error: Incompatible types in assignment (expression has type "B", variable has type "D")
+main:4: error: Incompatible types in assignment (expression has type "A", variable has type "D")
+main:5: error: Incompatible types in assignment (expression has type "D2", variable has type "D")
 
 
 -- Attribute access in class body
@@ -433,7 +433,7 @@ class A:
     c = x # type: A # E: Incompatible types in assignment (expression has type "B", variable has type "A")
     c = b   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testMethodRefInClassBody]
 from typing import Callable
@@ -447,7 +447,7 @@ class A:
     ff = f # type: Callable[[B], None]  # E: Incompatible types in assignment (expression has type Callable[[A], None], variable has type Callable[[B], None])
     g = ff                # E: Incompatible types in assignment (expression has type Callable[[B], None], variable has type Callable[[A], None])
 [out]
-main: In class "A":
+main: note: In class "A":
 
 
 -- Arbitrary statements in class body
@@ -466,7 +466,7 @@ class A:
     x = B() # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 [builtins fixtures/for.py]
 [out]
-main: In class "A":
+main: note: In class "A":
 
 
 -- Class attributes
@@ -568,7 +568,7 @@ def f() -> None:
     a.g()
     a.g(a) # E: Too many arguments for "g" of "A"
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testConstructNestedClass]
 import typing
@@ -578,7 +578,7 @@ class A:
     b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
     b = B(b) # E: Too many arguments for "B"
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testConstructNestedClassWithCustomInit]
 import typing
@@ -590,7 +590,7 @@ class A:
         b = A() # E: Incompatible types in assignment (expression has type "A", variable has type "B")
         b = B() # E: Too few arguments for "B"
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 [case testDeclareVariableWithNestedClassType]
 
@@ -600,7 +600,7 @@ def f() -> None:
     a = A()
     a = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testExternalReferenceToClassWithinClass]
 
@@ -645,7 +645,7 @@ A()
 class A: pass
 class A: pass
 [out]
-main, line 4: Name 'A' already defined
+main:4: error: Name 'A' already defined
 
 [case testDocstringInClass]
 import typing
@@ -664,10 +664,10 @@ class A:
             a = None
         b = None
 [out]
-main: In function "g":
-main, line 5: Need type annotation for variable
-main: In member "f" of class "A":
-main, line 6: Need type annotation for variable
+main: note: In function "g":
+main:5: error: Need type annotation for variable
+main: note: In member "f" of class "A":
+main:6: error: Need type annotation for variable
 
 
 -- Static methods
@@ -770,7 +770,7 @@ class A:
         self.x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/property.py]
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 [case testDynamicallyTypedProperty]
 import typing
@@ -820,7 +820,7 @@ a.f.x # E: "int" has no attribute "x"
 import typing
 class A(int, str): pass # E: Instance layout conflict in multiple inheritance
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testInvalidMultipleInheritanceFromBuiltins]
 import typing
@@ -828,7 +828,7 @@ class S(str): pass
 class A(S, str): pass
 class B(S, int): pass # E: Instance layout conflict in multiple inheritance
 [out]
-main: In class "B":
+main: note: In class "B":
 
 
 -- _promote decorators
@@ -885,7 +885,7 @@ class B(A):
     @overload
     def __add__(self, x: str) -> str: pass
 [out]
-main: In class "B":
+main: note: In class "B":
 
 [case testOperatorMethodOverrideWideningArgumentType]
 import typing
@@ -949,8 +949,8 @@ class B(A):
     @overload
     def __add__(self, x: type) -> A: pass
 [out]
-main: In class "B":
-main, line 8: Signature of "__add__" incompatible with supertype "A"
+main: note: In class "B":
+main:8: error: Signature of "__add__" incompatible with supertype "A"
 
 [case testOverloadedOperatorMethodOverrideWithSwitchedItemOrder]
 from typing import overload, Any
@@ -965,8 +965,8 @@ class B(A):
     @overload
     def __add__(self, x: 'B') -> 'B': pass
 [out]
-main: In class "B":
-main, line 8: Signature of "__add__" incompatible with supertype "A"
+main: note: In class "B":
+main:8: error: Signature of "__add__" incompatible with supertype "A"
 
 [case testReverseOperatorMethoddArgumentType]
 from typing import Any
@@ -978,8 +978,8 @@ class C:
 class D:
     def __radd__(self, x: A) -> object: pass
 [out]
-main: In member "__radd__" of class "B":
-main, line 4: "Any" return type expected since argument to __radd__ does not support __add__
+main: note: In member "__radd__" of class "B":
+main:4: error: "Any" return type expected since argument to __radd__ does not support __add__
 
 [case testReverseOperatorMethoddArgumentType2]
 from typing import Any, Tuple, Callable
@@ -990,12 +990,12 @@ class B:
 class C:
     def __radd__(self, x: Any) -> int: pass
 [out]
-main: In member "__radd__" of class "A":
-main, line 3: "Any" return type expected since argument to __radd__ does not support __add__
-main: In member "__radd__" of class "B":
-main, line 5: "Any" return type expected since argument to __radd__ does not support __add__
-main: In member "__radd__" of class "C":
-main, line 7: "Any" return type expected since argument to __radd__ has type "Any"
+main: note: In member "__radd__" of class "A":
+main:3: error: "Any" return type expected since argument to __radd__ does not support __add__
+main: note: In member "__radd__" of class "B":
+main:5: error: "Any" return type expected since argument to __radd__ does not support __add__
+main: note: In member "__radd__" of class "C":
+main:7: error: "Any" return type expected since argument to __radd__ has type "Any"
 
 [case testOverloadedReverseOperatorMethodArgumentType]
 from typing import overload, Any
@@ -1005,8 +1005,8 @@ class A:
     @overload
     def __radd__(self, x: 'A') -> Any: pass
 [out]
-main: In member "__radd__" of class "A":
-main, line 4: "Any" return type expected since argument to __radd__ does not support __add__
+main: note: In member "__radd__" of class "A":
+main:4: error: "Any" return type expected since argument to __radd__ does not support __add__
 
 [case testReverseOperatorMethodArgumentTypeAndOverloadedMethod]
 from typing import overload
@@ -1029,8 +1029,8 @@ class B:
     @abstractmethod
     def __gt__(self, x: 'B') -> int: pass
 [out]
-main: In member "__lt__" of class "A":
-main, line 5: "Any" return type expected since argument to __lt__ does not support __gt__
+main: note: In member "__lt__" of class "A":
+main:5: error: "Any" return type expected since argument to __lt__ does not support __gt__
 
 [case testOperatorMethodsAndOverloadingSpecialCase]
 from typing import overload
@@ -1055,8 +1055,8 @@ class B:
 class X:
     def __add__(self, x): pass
 [out]
-main: In member "__radd__" of class "B":
-main, line 6: Signatures of "__radd__" of "B" and "__add__" of "X" are unsafely overlapping
+main: note: In member "__radd__" of class "B":
+main:6: error: Signatures of "__radd__" of "B" and "__add__" of "X" are unsafely overlapping
 
 [case testOverlappingNormalAndInplaceOperatorMethod]
 import typing
@@ -1070,8 +1070,8 @@ class B:
     def __iadd__(self, x: A) -> int: pass
 class C(A): pass
 [out]
-main: In class "A":
-main, line 5: Signatures of "__iadd__" and "__add__" are incompatible
+main: note: In class "A":
+main:5: error: Signatures of "__iadd__" and "__add__" are incompatible
 
 [case testOverloadedNormalAndInplaceOperatorMethod]
 from typing import overload
@@ -1094,8 +1094,8 @@ class B:
     @overload
     def __iadd__(self, x: str) -> str: pass
 [out]
-main: In class "A":
-main, line 7: Signatures of "__iadd__" and "__add__" are incompatible
+main: note: In class "A":
+main:7: error: Signatures of "__iadd__" and "__add__" are incompatible
 
 [case testIntroducingInplaceOperatorInSubclass]
 import typing
@@ -1109,11 +1109,11 @@ class C(A):
 class D(A):
     def __iadd__(self, x: 'A') -> 'B': pass
 [out]
-main: In class "B":
-main, line 6: Return type of "__iadd__" incompatible with "__add__" of supertype "A"
-main: In class "C":
-main, line 8: Argument 1 of "__iadd__" incompatible with "__add__" of supertype "A"
-main, line 8: Signatures of "__iadd__" and "__add__" are incompatible
+main: note: In class "B":
+main:6: error: Return type of "__iadd__" incompatible with "__add__" of supertype "A"
+main: note: In class "C":
+main:8: error: Argument 1 of "__iadd__" incompatible with "__add__" of supertype "A"
+main:8: error: Signatures of "__iadd__" and "__add__" are incompatible
 
 
 [case testGetAttr]
@@ -1127,7 +1127,7 @@ class B: pass
 a = a.foo
 b = a.bar
 [out]
-main, line 9: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:9: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 
 [case testGetAttrSignature]
@@ -1140,10 +1140,10 @@ class C:
 class D:
     def __getattr__(self, x: str) -> None: pass
 [out]
-main: In member "__getattr__" of class "B":
-main, line 4: Invalid signature "def (self: __main__.B, x: __main__.A) -> __main__.B"
-main: In member "__getattr__" of class "C":
-main, line 6: Invalid signature "def (self: __main__.C, x: builtins.str, y: builtins.str) -> __main__.C"
+main: note: In member "__getattr__" of class "B":
+main:4: error: Invalid signature "def (self: __main__.B, x: __main__.A) -> __main__.B"
+main: note: In member "__getattr__" of class "C":
+main:6: error: Invalid signature "def (self: __main__.C, x: builtins.str, y: builtins.str) -> __main__.C"
 
 
 -- CallableType objects

--- a/mypy/test/data/check-dynamic-typing.test
+++ b/mypy/test/data/check-dynamic-typing.test
@@ -370,12 +370,12 @@ def f13(x, y = b, z = b): pass
 class A: pass
 class B: pass
 [out]
-main, line 10: Too many arguments for "f01"
-main, line 11: Too few arguments for "f13"
-main, line 12: Too many arguments for "f13"
-main, line 13: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[A, A], None])
-main, line 14: Incompatible types in assignment (expression has type Callable[[Any, Any, Any], Any], variable has type Callable[[], None])
-main, line 15: Incompatible types in assignment (expression has type Callable[[Any, Any, Any], Any], variable has type Callable[[A, A, A, A], None])
+main:10: error: Too many arguments for "f01"
+main:11: error: Too few arguments for "f13"
+main:12: error: Too many arguments for "f13"
+main:13: error: Incompatible types in assignment (expression has type Callable[[Any], Any], variable has type Callable[[A, A], None])
+main:14: error: Incompatible types in assignment (expression has type Callable[[Any, Any, Any], Any], variable has type Callable[[], None])
+main:15: error: Incompatible types in assignment (expression has type Callable[[Any, Any, Any], Any], variable has type Callable[[A, A, A, A], None])
 
 [case testSkipTypeCheckingWithImplicitSignature]
 
@@ -484,8 +484,8 @@ f2 = A
 class A:
   def __init__(self, a, b): pass
 [out]
-main, line 6: Too few arguments for "A"
-main, line 7: Incompatible types in assignment (expression has type "A" (type object), variable has type Callable[[A], A])
+main:6: error: Too few arguments for "A"
+main:7: error: Incompatible types in assignment (expression has type "A" (type object), variable has type Callable[[A], A])
 
 [case testUsingImplicitTypeObjectWithIs]
 
@@ -625,7 +625,7 @@ class A(B):
         pass
 class D: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testInvalidOverrideArgumentCountWithImplicitSignature1]
 import typing
@@ -644,7 +644,7 @@ class A(B):
     def f(self, x: 'A') -> None: # E: Signature of "f" incompatible with supertype "B"
         pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testInvalidOverrideArgumentCountWithImplicitSignature3]
 import typing
@@ -654,4 +654,4 @@ class A(B):
     def f(self, x, y) -> None: # E: Signature of "f" incompatible with supertype "B"
         x()
 [out]
-main: In class "A":
+main: note: In class "A":

--- a/mypy/test/data/check-expressions.test
+++ b/mypy/test/data/check-expressions.test
@@ -119,9 +119,9 @@ class A:
 class B: pass
 class C: pass
 [out]
-main, line 3: Unsupported operand types for + ("A" and "C")
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Unsupported left operand type for + ("B")
+main:3: error: Unsupported operand types for + ("A" and "C")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Unsupported left operand type for + ("B")
 [case testAdd]
 
 a, b, c = None, None, None # type: (A, B, C)
@@ -138,9 +138,9 @@ class B:
 class C:
     pass
 [out]
-main, line 3: Unsupported operand types for + ("A" and "C")
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Unsupported left operand type for + ("B")
+main:3: error: Unsupported operand types for + ("A" and "C")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Unsupported left operand type for + ("B")
 
 [case testSub]
 
@@ -158,9 +158,9 @@ class B:
 class C:
     pass
 [out]
-main, line 3: Unsupported operand types for - ("A" and "C")
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Unsupported left operand type for - ("B")
+main:3: error: Unsupported operand types for - ("A" and "C")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Unsupported left operand type for - ("B")
 
 [case testMul]
 
@@ -178,9 +178,9 @@ class B:
 class C:
     pass
 [out]
-main, line 3: Unsupported operand types for * ("A" and "C")
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Unsupported left operand type for * ("B")
+main:3: error: Unsupported operand types for * ("A" and "C")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Unsupported left operand type for * ("B")
 
 [case testDiv]
 
@@ -198,9 +198,9 @@ class B:
 class C:
     pass
 [out]
-main, line 3: Unsupported operand types for / ("A" and "C")
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Unsupported left operand type for / ("B")
+main:3: error: Unsupported operand types for / ("A" and "C")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Unsupported left operand type for / ("B")
 
 [case testIntDiv]
 
@@ -218,9 +218,9 @@ class B:
 class C:
     pass
 [out]
-main, line 3: Unsupported operand types for // ("A" and "C")
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Unsupported left operand type for // ("B")
+main:3: error: Unsupported operand types for // ("A" and "C")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Unsupported left operand type for // ("B")
 
 [case testMod]
 
@@ -238,9 +238,9 @@ class B:
 class C:
     pass
 [out]
-main, line 3: Unsupported operand types for % ("A" and "C")
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Unsupported left operand type for % ("B")
+main:3: error: Unsupported operand types for % ("A" and "C")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Unsupported left operand type for % ("B")
 
 [case testPow]
 
@@ -258,9 +258,9 @@ class B:
 class C:
     pass
 [out]
-main, line 3: Unsupported operand types for ** ("A" and "C")
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Unsupported left operand type for ** ("B")
+main:3: error: Unsupported operand types for ** ("A" and "C")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Unsupported left operand type for ** ("B")
 
 [case testMiscBinaryOperators]
 
@@ -284,11 +284,11 @@ class A:
   def __rshift__(self, x: 'B') -> 'B': pass
 class B: pass
 [out]
-main, line 3: Unsupported operand types for & ("A" and "A")
-main, line 4: Unsupported operand types for | ("A" and "B")
-main, line 5: Unsupported operand types for ^ ("A" and "A")
-main, line 6: Unsupported operand types for << ("A" and "B")
-main, line 7: Unsupported operand types for >> ("A" and "A")
+main:3: error: Unsupported operand types for & ("A" and "A")
+main:4: error: Unsupported operand types for | ("A" and "B")
+main:5: error: Unsupported operand types for ^ ("A" and "A")
+main:6: error: Unsupported operand types for << ("A" and "B")
+main:7: error: Unsupported operand types for >> ("A" and "A")
 
 [case testBooleanAndOr]
 
@@ -334,10 +334,10 @@ class D(Iterable[A]):
     def __iter__(self) -> Iterator[A]: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Unsupported operand types for in ("bool" and "A")
-main, line 4: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 5: Unsupported right operand type for in ("B")
-main, line 6: Unsupported operand types for in ("B" and "D")
+main:3: error: Unsupported operand types for in ("bool" and "A")
+main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:5: error: Unsupported right operand type for in ("B")
+main:6: error: Unsupported operand types for in ("B" and "D")
 
 [case testNotInOperator]
 from typing import Iterator, Iterable, Any
@@ -358,10 +358,10 @@ class D(Iterable[A]):
     def __iter__(self) -> Iterator[A]: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Unsupported operand types for in ("bool" and "A")
-main, line 4: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 5: Unsupported right operand type for in ("B")
-main, line 6: Unsupported operand types for in ("B" and "D")
+main:3: error: Unsupported operand types for in ("bool" and "A")
+main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:5: error: Unsupported right operand type for in ("B")
+main:6: error: Unsupported operand types for in ("B" and "D")
 
 [case testNonBooleanContainsReturnValue]
 
@@ -373,7 +373,7 @@ class A:
   def __contains__(self, x: 'A') -> object: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 4: Incompatible types in assignment (expression has type "object", variable has type "bool")
+main:4: error: Incompatible types in assignment (expression has type "object", variable has type "bool")
 
 [case testEq]
 
@@ -388,8 +388,8 @@ class A:
   def __ne__(self, o: object) -> bool: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 4: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testLtAndGt]
 
@@ -407,8 +407,8 @@ class B:
     def __gt__(self, o: 'B') -> bool: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 4: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testLeAndGe]
 
@@ -426,8 +426,8 @@ class B:
     def __ge__(self, o: 'B') -> bool: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 4: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testChainedComp]
 
@@ -444,9 +444,9 @@ class B:
     def __gt__(self, o: 'B') -> bool: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Unsupported operand types for > ("A" and "A")
-main, line 5: Unsupported operand types for > ("A" and "A")
-main, line 5: Unsupported operand types for < ("A" and "A")
+main:3: error: Unsupported operand types for > ("A" and "A")
+main:5: error: Unsupported operand types for > ("A" and "A")
+main:5: error: Unsupported operand types for < ("A" and "A")
 
 
 [case testChainedCompBoolRes]
@@ -463,7 +463,7 @@ class B:
     def __gt__(self, o: 'B') -> bool: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 4: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 
 [case testChainedCompResTyp]
@@ -492,8 +492,8 @@ class Y:
     def __eq__(self, o: 'Y') -> B: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 5: Incompatible types in assignment (expression has type "B", variable has type "bool")
-main, line 7: Incompatible types in assignment (expression has type "P", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "B", variable has type "bool")
+main:7: error: Incompatible types in assignment (expression has type "P", variable has type "A")
 
 
 [case testIs]
@@ -506,7 +506,7 @@ b = a is None
 class A: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testIsNot]
 
@@ -518,7 +518,7 @@ b = a is not None
 class A: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testReverseBinaryOperator]
 
@@ -584,12 +584,12 @@ class B:
     A()[1] # Error
 A()[1] # Error
 [out]
-main: In function "f":
-main, line 5: Invalid index type "int" for "A"
-main: In class "B":
-main, line 7: Invalid index type "int" for "A"
-main: At top level:
-main, line 8: Invalid index type "int" for "A"
+main: note: In function "f":
+main:5: error: Invalid index type "int" for "A"
+main: note: In class "B":
+main:7: error: Invalid index type "int" for "A"
+main: note: At top level:
+main:8: error: Invalid index type "int" for "A"
 
 [case testErrorContextAndBinaryOperators2]
 import m
@@ -603,13 +603,13 @@ class B:
     A()[1] # Error
 A()[1] # Error
 [out]
-In module imported in main, line 1:
-tmp/m.py: In function "f":
-tmp/m.py, line 5: Invalid index type "int" for "A"
-tmp/m.py: In class "B":
-tmp/m.py, line 7: Invalid index type "int" for "A"
-tmp/m.py: At top level:
-tmp/m.py, line 8: Invalid index type "int" for "A"
+main:1: note: In module imported here:
+tmp/m.py: note: In function "f":
+tmp/m.py:5: error: Invalid index type "int" for "A"
+tmp/m.py: note: In class "B":
+tmp/m.py:7: error: Invalid index type "int" for "A"
+tmp/m.py: note: At top level:
+tmp/m.py:8: error: Invalid index type "int" for "A"
 
 
 -- Unary operators
@@ -629,8 +629,8 @@ class A:
 class B:
     pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 4: Unsupported operand type for unary - ("B")
+main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:4: error: Unsupported operand type for unary - ("B")
 
 [case testUnaryPlus]
 
@@ -645,8 +645,8 @@ class A:
 class B:
     pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 4: Unsupported operand type for unary + ("B")
+main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:4: error: Unsupported operand type for unary + ("B")
 
 [case testUnaryNot]
 
@@ -658,7 +658,7 @@ class A:
     pass
 [builtins fixtures/bool.py]
 [out]
-main, line 3: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testUnaryBitwiseNeg]
 
@@ -673,8 +673,8 @@ class A:
 class B:
     pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 4: Unsupported operand type for ~ ("B")
+main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:4: error: Unsupported operand type for ~ ("B")
 
 
 -- Indexing
@@ -695,9 +695,9 @@ class A:
 class B: pass
 class C: pass
 [out]
-main, line 3: Invalid index type "C" for "A"
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 5: Value of type "B" is not indexable
+main:3: error: Invalid index type "C" for "A"
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:5: error: Value of type "B" is not indexable
 
 [case testIndexingAsLvalue]
 
@@ -715,9 +715,9 @@ class B:
 class C:
     pass
 [out]
-main, line 3: Invalid index type "C" for "A"
-main, line 4: Incompatible types in assignment
-main, line 5: Unsupported target for indexed assignment
+main:3: error: Invalid index type "C" for "A"
+main:4: error: Incompatible types in assignment
+main:5: error: Unsupported target for indexed assignment
 
 
 -- Cast expression
@@ -752,7 +752,7 @@ b = Any(a)
 class A: pass
 class B: pass
 [out]
-main, line 3: "A" not callable
+main:3: error: "A" not callable
 
 
 -- None return type
@@ -776,10 +776,10 @@ class A:
     def g(self, x: object) -> None:
         pass
 [out]
-main, line 3: "f" does not return a value
-main, line 4: "g" of "A" does not return a value
-main, line 5: "f" does not return a value
-main, line 6: "f" does not return a value
+main:3: error: "f" does not return a value
+main:4: error: "g" of "A" does not return a value
+main:5: error: "f" does not return a value
+main:6: error: "f" does not return a value
 
 [case testNoneReturnTypeWithStatements]
 import typing
@@ -796,12 +796,12 @@ def g() -> object:
 def f() -> None: pass
 [builtins fixtures/exception.py]
 [out]
-main, line 2: "f" does not return a value
-main, line 3: "f" does not return a value
-main, line 5: "f" does not return a value
-main, line 7: "f" does not return a value
-main: In function "g":
-main, line 10: "f" does not return a value
+main:2: error: "f" does not return a value
+main:3: error: "f" does not return a value
+main:5: error: "f" does not return a value
+main:7: error: "f" does not return a value
+main: note: In function "g":
+main:10: error: "f" does not return a value
 
 [case testNoneReturnTypeWithExpressions]
 from typing import cast
@@ -1026,9 +1026,9 @@ f = lambda: 1 # type: Callable[[], int]
 f = lambda: ''.x
 f = lambda: ''
 [out]
-main, line 3: "str" has no attribute "x"
-main, line 4: Incompatible return value type: expected builtins.int, got builtins.str
-main, line 4: Incompatible types in assignment (expression has type Callable[[], str], variable has type Callable[[], int])
+main:3: error: "str" has no attribute "x"
+main:4: error: Incompatible return value type: expected builtins.int, got builtins.str
+main:4: error: Incompatible types in assignment (expression has type Callable[[], str], variable has type Callable[[], int])
 
 [case testVoidLambda]
 import typing
@@ -1124,9 +1124,9 @@ class A: pass
 class B: pass
 [builtins fixtures/dict.py]
 [out]
-main, line 5: Key expression in dictionary comprehension has incompatible type "A"; expected type "B"
-main, line 5: Value expression in dictionary comprehension has incompatible type "B"; expected type "A"
-main, line 6: Incompatible types in assignment (expression has type Dict[A, B], variable has type "A")
+main:5: error: Key expression in dictionary comprehension has incompatible type "A"; expected type "B"
+main:5: error: Value expression in dictionary comprehension has incompatible type "B"; expected type "A"
+main:6: error: Incompatible types in assignment (expression has type Dict[A, B], variable has type "A")
 
 
 [case testDictionaryComprehensionWithNonDirectMapping]
@@ -1140,8 +1140,8 @@ class C: pass
 def f(b: A) -> C: pass
 [builtins fixtures/dict.py]
 [out]
-main, line 4: Argument 1 to "f" has incompatible type "B"; expected "A"
-main, line 4: Value expression in dictionary comprehension has incompatible type "C"; expected type "B"
+main:4: error: Argument 1 to "f" has incompatible type "B"; expected "A"
+main:4: error: Value expression in dictionary comprehension has incompatible type "C"; expected type "B"
 
 
 -- Generator expressions
@@ -1211,9 +1211,9 @@ cast(A, f)
 def f() -> None:
     pass
 [out]
-main, line 5: Unsupported left operand type for + (None)
-main, line 6: Unsupported left operand type for + (Callable[[], None])
-main, line 7: Unsupported operand types for + ("A" and Callable[[], None])
+main:5: error: Unsupported left operand type for + (None)
+main:6: error: Unsupported left operand type for + (Callable[[], None])
+main:7: error: Unsupported operand types for + ("A" and Callable[[], None])
 
 [case testOperatorMethodWithInvalidArgCount]
 
@@ -1224,7 +1224,7 @@ class A:
     def __add__(self) -> 'A':
         pass
 [out]
-main, line 3: Too many arguments for "__add__" of "A"
+main:3: error: Too many arguments for "__add__" of "A"
 
 [case testOperatorMethodAsVar]
 from typing import Any
@@ -1244,7 +1244,7 @@ s = None  # type: str
 s = A() + 1
 A() + (A() + 1)
 [out]
-main, line 7: Argument 1 has incompatible type "str"; expected "int"
+main:7: error: Argument 1 has incompatible type "str"; expected "int"
 
 [case testIndexedLvalueWithSubtypes]
 

--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -209,7 +209,7 @@ def f(x: 'A' = A()) -> None:
 class B: pass
 class A: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testDefaultArgumentExpressions2]
 import typing
@@ -220,7 +220,7 @@ def f(x: 'A' = B()) -> None: # E: Incompatible types in assignment (expression h
 class B: pass
 class A: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testDefaultArgumentsWithSubtypes]
 import typing
@@ -232,7 +232,7 @@ def g(x: 'A' = B()) -> None:
 class A: pass
 class B(A): pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testMultipleDefaultArgumentExpressions]
 import typing
@@ -244,7 +244,7 @@ def h(x: 'A' = A(), y: 'B' = B()) -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testMultipleDefaultArgumentExpressions2]
 import typing
@@ -254,7 +254,7 @@ def g(x: 'A' = A(), y: 'B' = A()) -> None: # E: Incompatible types in assignment
 class A: pass
 class B: pass
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testDefaultArgumentsAndSignatureAsComment]
 import typing
@@ -402,10 +402,10 @@ def f(a: 'A') -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "g":
-main, line 4: Incompatible types in assignment (expression has type "A", variable has type "B")
-main: In function "f":
-main, line 7: Argument 1 to "g" has incompatible type "A"; expected "B"
+main: note: In function "g":
+main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+main: note: In function "f":
+main:7: error: Argument 1 to "g" has incompatible type "A"; expected "B"
 
 [case testReturnAndNestedFunction]
 import typing
@@ -418,10 +418,10 @@ def f() -> 'A':
 class A: pass
 class B: pass
 [out]
-main: In function "g":
-main, line 4: Incompatible return value type: expected __main__.B, got __main__.A
-main: In function "f":
-main, line 6: Incompatible return value type: expected __main__.A, got __main__.B
+main: note: In function "g":
+main:4: error: Incompatible return value type: expected __main__.B, got __main__.A
+main: note: In function "f":
+main:6: error: Incompatible return value type: expected __main__.A, got __main__.B
 
 [case testDynamicallyTypedNestedFunction]
 import typing
@@ -431,7 +431,7 @@ def f(x: object) -> None:
     g() # E: Too few arguments for "g"
     g(x)
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testNestedFunctionInMethod]
 import typing
@@ -443,10 +443,10 @@ class A:
         g(2)
         g(A()) # fail
 [out]
-main: In function "g":
-main, line 6: Incompatible types in assignment (expression has type "int", variable has type "A")
-main: In member "f" of class "A":
-main, line 8: Argument 1 to "g" of "A" has incompatible type "A"; expected "int"
+main: note: In function "g":
+main:6: error: Incompatible types in assignment (expression has type "int", variable has type "A")
+main: note: In member "f" of class "A":
+main:8: error: Argument 1 to "g" of "A" has incompatible type "A"; expected "int"
 
 
 -- Casts
@@ -502,7 +502,7 @@ def g() -> None:
     f(1)
     f('') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testCheckingDecoratedFunction]
 import typing
@@ -513,7 +513,7 @@ def f(x: 'A') -> None:
     x = object() # E: Incompatible types in assignment (expression has type "object", variable has type "A")
 class A: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testDecoratorThatSwitchesType]
 from typing import Callable
@@ -618,7 +618,7 @@ if x:
         x = 1
         x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testCallConditionalFunction]
 from typing import Any
@@ -644,11 +644,11 @@ else:
 f(1)
 f('x') # fail
 [out]
-main: In function "f":
-main, line 5: Incompatible types in assignment (expression has type "str", variable has type "int")
-main, line 9: Unsupported left operand type for + ("int")
-main: At top level:
-main, line 12: Argument 1 to "f" has incompatible type "str"; expected "int"
+main: note: In function "f":
+main:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:9: error: Unsupported left operand type for + ("int")
+main: note: At top level:
+main:12: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testUnconditionalRedefinitionOfConditionalFunction]
 from typing import Any
@@ -695,7 +695,7 @@ class A:
             x = 1
             x = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 [case testCallConditionalMethodInClassBody]
 from typing import Any
@@ -708,7 +708,7 @@ class A:
     f(x, 1)
     f(x, 'x') # E: Argument 2 to "f" of "A" has incompatible type "str"; expected "int"
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testCallConditionalMethodViaInstance]
 from typing import Any
@@ -734,11 +734,11 @@ class A:
 A().f(1)
 A().f('x') # fail
 [out]
-main: In member "f" of class "A":
-main, line 6: Incompatible types in assignment (expression has type "str", variable has type "int")
-main, line 10: Unsupported left operand type for + ("int")
-main: At top level:
-main, line 13: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+main: note: In member "f" of class "A":
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:10: error: Unsupported left operand type for + ("int")
+main: note: At top level:
+main:13: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 
 [case testUnconditionalRedefinitionOfConditionalMethod]
 from typing import Any
@@ -757,7 +757,7 @@ class A:
     else:
         def f(self, x): pass # E: All conditional function variants must have identical signatures
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testConditionalFunctionDefinitionInTry]
 import typing
@@ -783,7 +783,7 @@ def f(x: Callable[..., int]) -> None:
     x(z=1)
     x() + '' # E: Unsupported left operand type for + ("int")
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testCallableWithArbitraryArgs2]
 from typing import Callable
@@ -801,7 +801,7 @@ from typing import Callable
 def f(x: Callable[..., int]) -> None:
     x = 1  # E: Incompatible types in assignment (expression has type "int", variable has type Callable[..., int])
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testCallableWithArbitraryArgsInGenericFunction]
 from typing import Callable, TypeVar

--- a/mypy/test/data/check-generic-subtyping.test
+++ b/mypy/test/data/check-generic-subtyping.test
@@ -175,7 +175,7 @@ class A(B[C]):
         # E: Argument 1 of "f" incompatible with supertype "B"
     def g(self, a: C) -> None: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testOverridingMethodInGenericTypeInheritingSimpleType]
 from typing import TypeVar, Generic
@@ -189,7 +189,7 @@ class A(B, Generic[T]):
         # E: Argument 1 of "f" incompatible with supertype "B"
     def g(self, a: 'C') -> None: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testOverridingMethodInGenericTypeInheritingGenericType]
 from typing import TypeVar, Generic
@@ -203,7 +203,7 @@ class A(B[S], Generic[T, S]):
         # E: Argument 1 of "f" incompatible with supertype "B"
     def g(self, a: S) -> None: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testOverridingMethodInMultilevelHierarchyOfGenericTypes]
 from typing import TypeVar, Generic
@@ -222,7 +222,7 @@ class A(B[S], Generic[T, S]):
         # E: Argument 1 of "f" incompatible with supertype "C"
     def g(self, a: S) -> None: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 
 -- Inheritance from generic types with implicit dynamic supertype
@@ -288,7 +288,7 @@ class A(B):
 
 class C: pass
 [out]
-main: In member "g" of class "A":
+main: note: In member "g" of class "A":
 
 [case testInheritanceFromGenericWithImplicitDynamicAndOverriding]
 from typing import TypeVar, Generic, Tuple
@@ -317,7 +317,7 @@ class A(B[S], Generic[T, S]):
         super().f(t)   # E: Argument 1 to "f" of "B" has incompatible type "T"; expected "S"
         super().f(s)
 [out]
-main: In member "g" of class "A":
+main: note: In member "g" of class "A":
 
 [case testSuperExpressionsWhenInheritingFromGenericTypeAndDeepHierarchy]
 from typing import TypeVar, Generic
@@ -334,7 +334,7 @@ class A(B[S], Generic[T, S]):
         super().f(t)   # E: Argument 1 to "f" of "C" has incompatible type "T"; expected "S"
         super().f(s)
 [out]
-main: In member "g" of class "A":
+main: note: In member "g" of class "A":
 
 
 -- Subtyping with a generic abstract base class
@@ -399,8 +399,8 @@ class B(A, I[D]): pass # Fail
 class C: pass
 class D: pass
 [out]
-main: In class "B":
-main, line 5: Class "B" has base "I" duplicated inconsistently
+main: note: In class "B":
+main:5: error: Class "B" has base "I" duplicated inconsistently
 
 [case testSubtypingAndABCExtension]
 from typing import TypeVar, Generic
@@ -440,7 +440,7 @@ class A(I[C]):
 class C: pass
 class D: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 
 -- Extending a generic ABC with deep type hierarchy
@@ -472,8 +472,8 @@ class A(B):
 class C: pass
 class D: pass
 [out]
-main, line 7: Incompatible types in assignment (expression has type "A", variable has type I[D])
-main: In class "A":
+main:7: error: Incompatible types in assignment (expression has type "A", variable has type I[D])
+main: note: In class "A":
 
 [case testSubclassingGenenericABCWithDeepHierarchy2]
 from typing import Any, TypeVar, Generic
@@ -490,7 +490,7 @@ class A(B):
 class C: pass
 class D: pass
 [out]
-main: In class "A":
+main: note: In class "A":
 
 
 -- Implicit Any types and subclassing generic ABC

--- a/mypy/test/data/check-generics.test
+++ b/mypy/test/data/check-generics.test
@@ -15,7 +15,7 @@ class A(Generic[T]):
 class B: pass
 class C: pass
 [out]
-main, line 4: Incompatible types in assignment (expression has type "B", variable has type "C")
+main:4: error: Incompatible types in assignment (expression has type "B", variable has type "C")
 
 [case testGenericMethodArgument]
 from typing import TypeVar, Generic
@@ -33,7 +33,7 @@ class A(Generic[T]):
 class B: pass
 class C: pass
 [out]
-main, line 3: Argument 1 to "f" of "A" has incompatible type "C"; expected "B"
+main:3: error: Argument 1 to "f" of "A" has incompatible type "C"; expected "B"
 
 [case testGenericMemberVariable]
 from typing import TypeVar, Generic
@@ -49,7 +49,7 @@ a.v = b
 class B: pass
 class C: pass
 [out]
-main, line 8: Incompatible types in assignment (expression has type "C", variable has type "B")
+main:8: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 [case testGenericMemberVariable]
 from typing import TypeVar, Generic
@@ -63,7 +63,7 @@ class A(Generic[T]):
 class B: pass
 class C: pass
 [out]
-main, line 4: Incompatible types in assignment (expression has type "C", variable has type "B")
+main:4: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 [case testSimpleGenericSubtyping]
 from typing import TypeVar, Generic
@@ -79,8 +79,8 @@ class A(Generic[T]): pass
 class B: pass
 class C(B): pass
 [out]
-main, line 4: Incompatible types in assignment (expression has type A[B], variable has type A[C])
-main, line 5: Incompatible types in assignment (expression has type A[C], variable has type A[B])
+main:4: error: Incompatible types in assignment (expression has type A[B], variable has type A[C])
+main:5: error: Incompatible types in assignment (expression has type A[C], variable has type A[B])
 
 [case testGenericTypeCompatibilityWithAny]
 from typing import Any, TypeVar, Generic
@@ -115,8 +115,8 @@ class A(Generic[T]):
 class B: pass
 class C: pass
 [out]
-main, line 7: Incompatible types in assignment (expression has type A[C], variable has type A[B])
-main, line 8: Incompatible types in assignment (expression has type A[B], variable has type A[C])
+main:7: error: Incompatible types in assignment (expression has type A[C], variable has type A[B])
+main:8: error: Incompatible types in assignment (expression has type A[B], variable has type A[C])
 
 [case testMultipleGenericTypeParametersWithMemberVars]
 from typing import TypeVar, Generic
@@ -138,8 +138,8 @@ class A(Generic[S, T]):
 class B: pass
 class C: pass
 [out]
-main, line 8: Incompatible types in assignment (expression has type "B", variable has type "C")
-main, line 9: Incompatible types in assignment (expression has type "C", variable has type "B")
+main:8: error: Incompatible types in assignment (expression has type "B", variable has type "C")
+main:9: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 [case testMultipleGenericTypeParametersWithMethods]
 from typing import TypeVar, Generic
@@ -158,8 +158,8 @@ class A(Generic[S, T]):
 class B: pass
 class C: pass
 [out]
-main, line 8: Argument 2 to "f" of "A" has incompatible type "B"; expected "C"
-main, line 9: Argument 1 to "f" of "A" has incompatible type "C"; expected "B"
+main:8: error: Argument 2 to "f" of "A" has incompatible type "B"; expected "C"
+main:9: error: Argument 1 to "f" of "A" has incompatible type "C"; expected "B"
 
 [case testMultipleGenericTypeParametersAndSubtyping]
 from typing import TypeVar, Generic
@@ -183,9 +183,9 @@ class A(Generic[S, T]):
 class B: pass
 class C(B):pass
 [out]
-main, line 8: Incompatible types in assignment (expression has type A[B, C], variable has type A[B, B])
-main, line 9: Incompatible types in assignment (expression has type A[C, B], variable has type A[B, B])
-main, line 10: Incompatible types in assignment (expression has type A[B, B], variable has type A[B, C])
+main:8: error: Incompatible types in assignment (expression has type A[B, C], variable has type A[B, B])
+main:9: error: Incompatible types in assignment (expression has type A[C, B], variable has type A[B, B])
+main:10: error: Incompatible types in assignment (expression has type A[B, B], variable has type A[B, C])
 
 
 -- Simple generic type bodies
@@ -207,9 +207,9 @@ class A(Generic[T]):
 x = None # type: B
 class B: pass
 [out]
-main: In member "f" of class "A":
-main, line 7: Argument 1 to "f" of "A" has incompatible type "B"; expected "T"
-main, line 8: Incompatible types in assignment (expression has type A[T], variable has type A[B])
+main: note: In member "f" of class "A":
+main:7: error: Argument 1 to "f" of "A" has incompatible type "B"; expected "T"
+main:8: error: Incompatible types in assignment (expression has type A[T], variable has type A[B])
 
 [case testGenericTypeBodyWithMultipleVariables]
 from typing import TypeVar, Generic
@@ -228,11 +228,11 @@ class A(Generic[S, T]):
 
 class B: pass
 [out]
-main: In member "f" of class "A":
-main, line 8: Incompatible types in assignment (expression has type "T", variable has type "S")
-main, line 9: Incompatible types in assignment (expression has type "S", variable has type "T")
-main, line 10: Incompatible types in assignment (expression has type A[S, T], variable has type A[S, B])
-main, line 11: Incompatible types in assignment (expression has type A[S, T], variable has type A[T, T])
+main: note: In member "f" of class "A":
+main:8: error: Incompatible types in assignment (expression has type "T", variable has type "S")
+main:9: error: Incompatible types in assignment (expression has type "S", variable has type "T")
+main:10: error: Incompatible types in assignment (expression has type A[S, T], variable has type A[S, B])
+main:11: error: Incompatible types in assignment (expression has type A[S, T], variable has type A[T, T])
 
 [case testCompatibilityOfNoneWithTypeVar]
 from typing import TypeVar, Generic
@@ -253,9 +253,9 @@ class A(Generic[T]):
         b = self.f() # type: object
         b = self.f()
 [out]
-main: In member "f" of class "A":
-main, line 5: Incompatible types in assignment (expression has type "object", variable has type "T")
-main, line 6: Incompatible types in assignment (expression has type "object", variable has type "T")
+main: note: In member "f" of class "A":
+main:5: error: Incompatible types in assignment (expression has type "object", variable has type "T")
+main:6: error: Incompatible types in assignment (expression has type "object", variable has type "T")
 
 
 -- Operations with generic types
@@ -285,10 +285,10 @@ class A(Generic[S, T]):
 class B: pass
 class C: pass
 [out]
-main, line 8: Incompatible types in assignment (expression has type "C", variable has type "B")
-main, line 9: Unsupported operand types for + ("A" and "C")
-main, line 10: Incompatible types in assignment (expression has type "B", variable has type "C")
-main, line 11: Invalid index type "B" for "A"
+main:8: error: Incompatible types in assignment (expression has type "C", variable has type "B")
+main:9: error: Unsupported operand types for + ("A" and "C")
+main:10: error: Incompatible types in assignment (expression has type "B", variable has type "C")
+main:11: error: Invalid index type "B" for "A"
 
 [case testOperatorAssignmentWithIndexLvalue1]
 from typing import TypeVar, Generic
@@ -310,9 +310,9 @@ class B: pass
 class C:
     def __add__(self, o: 'C') -> 'C': pass
 [out]
-main, line 7: Unsupported operand types for + ("C" and "B")
-main, line 7: Incompatible types in assignment
-main, line 8: Invalid index type "C" for "A"
+main:7: error: Unsupported operand types for + ("C" and "B")
+main:7: error: Incompatible types in assignment
+main:8: error: Invalid index type "C" for "A"
 
 [case testOperatorAssignmentWithIndexLvalue2]
 from typing import TypeVar, Generic
@@ -333,9 +333,9 @@ class B: pass
 class C:
     def __add__(self, o: 'C') -> 'C': pass
 [out]
-main, line 7: Invalid index type "B" for "A"
-main, line 8: Invalid index type "C" for "A"
-main, line 9: Invalid index type "B" for "A"
+main:7: error: Invalid index type "B" for "A"
+main:8: error: Invalid index type "C" for "A"
+main:9: error: Invalid index type "B" for "A"
 
 
 -- Nested generic types
@@ -367,8 +367,8 @@ class B:
 class C:
     pass
 [out]
-main, line 8: Incompatible types in assignment (expression has type A[B], variable has type A[C])
-main, line 9: Incompatible types in assignment (expression has type A[A[B]], variable has type A[A[C]])
+main:8: error: Incompatible types in assignment (expression has type A[B], variable has type A[C])
+main:9: error: Incompatible types in assignment (expression has type A[A[B]], variable has type A[A[C]])
 
 
 -- Generic functions
@@ -393,7 +393,7 @@ def f(s: S, t: T) -> p[T, A]:
     p_t_a = None  # type: p[T, A]
     return p_t_a
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testTypeCheckingGenericMethodBody]
 from typing import TypeVar, Generic
@@ -415,7 +415,7 @@ class A(Generic[T]):
         p_s_t = None  # type: p[S, T]
         return p_s_t
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 
 -- Generic types in expressions
@@ -446,8 +446,8 @@ class A: pass
 a[A]() # Fail
 A[A]() # Fail
 [out]
-main, line 4: Value of type "A" is not indexable
-main, line 5: Generic type not valid as an expression any more (use '# type:' comment instead)
+main:4: error: Value of type "A" is not indexable
+main:5: error: Generic type not valid as an expression any more (use '# type:' comment instead)
 
 
 -- Multiple assignment with lists
@@ -624,7 +624,7 @@ def f() -> None:
     a = 1
     a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testClassLevelTypeVariable]
 from typing import TypeVar
@@ -688,8 +688,8 @@ def f(a: T, b: T) -> T:
         return b
 [builtins fixtures/ops.py]
 [out]
-main: In function "f":
-main, line 4: Unsupported left operand type for < ("T")
+main: note: In function "f":
+main:4: error: Unsupported left operand type for < ("T")
 
 
 -- Special cases

--- a/mypy/test/data/check-inference-context.test
+++ b/mypy/test/data/check-inference-context.test
@@ -85,7 +85,7 @@ def f(a: T) -> 'A[T]': pass
 class A(Generic[T]): pass
 class B: pass
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testInferLocalVariableTypeWithUnderspecifiedGenericType]
 from typing import TypeVar, Generic
@@ -96,7 +96,7 @@ def g() -> None:
 def f() -> 'A[T]': pass
 class A(Generic[T]): pass
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testInferMultipleLocalVariableTypesWithTupleRvalue]
 from typing import TypeVar, Generic
@@ -115,7 +115,7 @@ def f(a: T) -> 'A[T]': pass
 class A(Generic[T]): pass
 class B: pass
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testInferMultipleLocalVariableTypesWithArrayRvalueAndNesting]
 from typing import TypeVar, List, Generic
@@ -137,7 +137,7 @@ class A(Generic[T]): pass
 class B: pass
 [builtins fixtures/for.py]
 [out]
-main: In function "h":
+main: note: In function "h":
 
 
 -- Return types with multiple tvar instances
@@ -165,8 +165,8 @@ class A(Generic[T]): pass
 class B: pass
 [builtins fixtures/tuple.py]
 [out]
-main, line 8: Incompatible types in assignment (expression has type A[B], variable has type A[object])
-main, line 9: Incompatible types in assignment (expression has type A[B], variable has type A[object])
+main:8: error: Incompatible types in assignment (expression has type A[B], variable has type A[object])
+main:9: error: Incompatible types in assignment (expression has type A[B], variable has type A[object])
 
 [case testInferenceWithTypeVariableTwiceInReturnTypeAndMultipleVariables]
 from typing import TypeVar, Tuple, Generic
@@ -194,10 +194,10 @@ class A(Generic[T]): pass
 class B: pass
 [builtins fixtures/tuple.py]
 [out]
-main, line 9: Incompatible types in assignment (expression has type A[B], variable has type A[object])
-main, line 10: Incompatible types in assignment (expression has type A[B], variable has type A[object])
-main, line 11: Incompatible types in assignment (expression has type A[B], variable has type A[object])
-main, line 12: Incompatible types in assignment (expression has type A[B], variable has type A[object])
+main:9: error: Incompatible types in assignment (expression has type A[B], variable has type A[object])
+main:10: error: Incompatible types in assignment (expression has type A[B], variable has type A[object])
+main:11: error: Incompatible types in assignment (expression has type A[B], variable has type A[object])
+main:12: error: Incompatible types in assignment (expression has type A[B], variable has type A[object])
 
 
 -- Multiple tvar instances in arguments
@@ -396,7 +396,7 @@ def f() -> None:
 class B: pass
 [builtins fixtures/list.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testNestedListExpressions]
 from typing import List
@@ -487,7 +487,7 @@ class B: pass
 class C(B): pass
 class D: pass
 [out]
-main: In function "t":
+main: note: In function "t":
 
 [case testIntersectionWithInferredGenericArgument]
 from typing import overload, TypeVar, Generic
@@ -589,9 +589,9 @@ f = lambda x: A() # type: Callable[[], A]
 f2 = lambda: A() # type: Callable[[A], A]
 class A: pass
 [out]
-main, line 2: Cannot infer type of lambda
-main, line 3: Cannot infer type of lambda
-main, line 3: Incompatible types in assignment (expression has type Callable[[], A], variable has type Callable[[A], A])
+main:2: error: Cannot infer type of lambda
+main:3: error: Cannot infer type of lambda
+main:3: error: Incompatible types in assignment (expression has type Callable[[], A], variable has type Callable[[A], A])
 
 
 -- Overloads + generic functions

--- a/mypy/test/data/check-inference.test
+++ b/mypy/test/data/check-inference.test
@@ -13,8 +13,8 @@ x = x
 class A: pass
 class B: pass
 [out]
-main, line 4: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 6: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:6: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testInferSimpleLvarType]
 import typing
@@ -28,9 +28,9 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
-main, line 5: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 7: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In function "f":
+main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:7: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testLvarInitializedToNoneWithoutType]
 import typing
@@ -38,7 +38,7 @@ def f() -> None:
     a = None # E: Need type annotation for variable
     a.x()
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testLvarInitializedToVoid]
 import typing
@@ -48,7 +48,7 @@ def f() -> None:
 
 def g() -> None: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypeFromArgument]
 import typing
@@ -61,7 +61,7 @@ def f(a: 'A') -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypeFromGvar]
 
@@ -75,7 +75,7 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringImplicitDynamicTypeForLvar]
 import typing
@@ -86,7 +86,7 @@ def f() -> None:
 
 def g(): pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringExplicitDynamicTypeForLvar]
 from typing import Any
@@ -97,7 +97,7 @@ def f(a: Any) -> None:
     None(b) # E: None not callable
     a.x()
 [out]
-main: In function "f":
+main: note: In function "f":
 
 
 -- Inferring types of local variables with complex types
@@ -119,7 +119,7 @@ class A: pass
 class B: pass
 [builtins fixtures/tuple.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringTupleTypeForLvarWithNones]
 import typing
@@ -130,7 +130,7 @@ def f() -> None:
 class A: pass
 [builtins fixtures/tuple.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringGenericTypeForLvar]
 from typing import TypeVar, Generic
@@ -146,7 +146,7 @@ def f() -> None:
     a = a_i
 [builtins fixtures/tuple.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringFunctionTypeForLvar]
 import typing
@@ -160,7 +160,7 @@ def g(a: 'A') -> None: pass
 class A: pass
 class B: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringFunctionTypeForLvarFromTypeObject]
 import typing
@@ -172,7 +172,7 @@ def f() -> None:
 
 class A: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 
 -- Inferring variable types in multiple definition
@@ -193,7 +193,7 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypesInTupleAssignment]
 from typing import Tuple
@@ -210,7 +210,7 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypesInNestedTupleAssignment1]
 from typing import Tuple
@@ -227,7 +227,7 @@ def f() -> None:
 class A: pass
 class B: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypesInNestedTupleAssignment2]
 import typing
@@ -246,7 +246,7 @@ class A: pass
 class B: pass
 class C: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypesInNestedListAssignment]
 import typing
@@ -265,7 +265,7 @@ class A: pass
 class B: pass
 class C: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypesInMultiDefWithNoneTypes]
 import typing
@@ -275,7 +275,7 @@ def f() -> None:
 
 class A: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypesInNestedTupleAssignmentWithNoneTypes]
 import typing
@@ -284,7 +284,7 @@ def f() -> None:
 
 class A: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringLvarTypesInMultiDefWithInvalidTuple]
 from typing import Tuple
@@ -296,9 +296,9 @@ def f() -> None:
     g, h, i = t
 [builtins fixtures/tuple.py]
 [out]
-main: In function "f":
-main, line 5: Too many values to unpack (2 expected, 3 provided)
-main, line 6: Need more than 3 values to unpack (4 expected)
+main: note: In function "f":
+main:5: error: Too many values to unpack (2 expected, 3 provided)
+main:6: error: Need more than 3 values to unpack (4 expected)
 
 [case testInvalidRvalueTypeInInferredMultipleLvarDefinition]
 import typing
@@ -308,7 +308,7 @@ def f() -> None:
 class A: pass
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInvalidRvalueTypeInInferredNestedTupleAssignment]
 import typing
@@ -318,7 +318,7 @@ def f() -> None:
 class A: pass
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringMultipleLvarDefinitionWithListRvalue]
 from typing import List
@@ -347,7 +347,7 @@ def f() -> None:
     d = e
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringNestedTupleAssignmentWithListRvalue]
 from typing import List
@@ -376,7 +376,7 @@ def f() -> None:
     d = e
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInferringMultipleLvarDefinitionWithImplicitDynamicRvalue]
 import typing
@@ -443,7 +443,7 @@ def f() -> None:
 def id(x: T) -> T:
     return x
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testUnderspecifiedInferenceResult]
 from typing import TypeVar
@@ -461,7 +461,7 @@ g(a)
 def f() -> T: pass
 def g(a: T) -> None: pass
 [out]
-main: In function "ff":
+main: note: In function "ff":
 
 [case testUnsolvableInferenceResult]
 from typing import TypeVar
@@ -473,8 +473,8 @@ def f(a: T, b: T) -> None: pass
 def g() -> None: pass
 class A: pass
 [out]
-main, line 3: Cannot infer type argument 1 of "f"
-main, line 3: "g" does not return a value
+main:3: error: Cannot infer type argument 1 of "f"
+main:3: error: "g" does not return a value
 
 [case testInferenceWithMultipleConstraints]
 from typing import TypeVar
@@ -514,10 +514,10 @@ class A: pass
 class B: pass
 [builtins fixtures/tuple.py]
 [out]
-main, line 9: Argument 2 to "f" has incompatible type "B"; expected "A"
-main, line 10: Argument 1 to "f" has incompatible type "B"; expected "A"
-main, line 11: Argument 1 to "f" has incompatible type "A"; expected "B"
-main, line 11: Argument 2 to "f" has incompatible type "B"; expected "A"
+main:9: error: Argument 2 to "f" has incompatible type "B"; expected "A"
+main:10: error: Argument 1 to "f" has incompatible type "B"; expected "A"
+main:11: error: Argument 1 to "f" has incompatible type "A"; expected "B"
+main:11: error: Argument 2 to "f" has incompatible type "B"; expected "A"
 
 [case testConstraintSolvingWithSimpleGenerics]
 from typing import TypeVar, Generic
@@ -767,12 +767,12 @@ class B: pass
 class C: pass
 [builtins fixtures/for.py]
 [out]
-main, line 4: Incompatible types in assignment (expression has type "A", variable has type "B")
-main, line 5: Incompatible types in assignment (expression has type "B", variable has type "C")
-main, line 6: Incompatible types in assignment (expression has type "C", variable has type "A")
-main, line 10: Need more than 2 values to unpack (3 expected)
-main, line 12: '__main__.B' object is not iterable
-main, line 14: Need type annotation for variable
+main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:5: error: Incompatible types in assignment (expression has type "B", variable has type "C")
+main:6: error: Incompatible types in assignment (expression has type "C", variable has type "A")
+main:10: error: Need more than 2 values to unpack (3 expected)
+main:12: error: '__main__.B' object is not iterable
+main:14: error: Need type annotation for variable
 
 [case testInferenceOfFor3]
 
@@ -823,7 +823,7 @@ class A: pass
 class B: pass
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 
 -- Regression tests
@@ -893,7 +893,7 @@ class A:
         self.a = B()
 class B: pass
 [out]
-main: In member "__init__" of class "A":
+main: note: In member "__init__" of class "A":
 
 [case testInferAttributeInInit]
 import typing

--- a/mypy/test/data/check-isinstance.test
+++ b/mypy/test/data/check-isinstance.test
@@ -55,7 +55,7 @@ x = None # type: int
 y = [x]
 [builtins fixtures/isinstancelist.py]
 [out]
-main: In function "foo":
+main: note: In function "foo":
 
 [case testFunctionDefaultArgs]
 
@@ -68,7 +68,7 @@ def foo(x: A = B()):
     x.y   # E: "A" has no attribute "y"
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "foo":
+main: note: In function "foo":
 
 [case testIsinstanceFancyConditionals]
 
@@ -187,7 +187,7 @@ def bar() -> None:
     x + 'a'
 [builtins fixtures/isinstancelist.py]
 [out]
-main: In function "bar":
+main: note: In function "bar":
 
 [case testUnionTryExcept]
 
@@ -254,7 +254,7 @@ def f(x: Union[List[int], List[str], int]) -> None:
     x + 1 # E: Unsupported operand types for + (likely involving Union)
 [builtins fixtures/isinstancelist.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testUnionStrictDefnBasic]
 from typing import Union
@@ -420,7 +420,7 @@ def foo() -> None:
 foo()
 [builtins fixtures/isinstancelist.py]
 [out]
-main: In function "foo":
+main: note: In function "foo":
 [case testIsInstanceThreeUnion]
 from typing import Union, List
 
@@ -656,7 +656,7 @@ def bar() -> None:
 
 [builtins fixtures/isinstancelist.py]
 [out]
-main: In function "bar":
+main: note: In function "bar":
 
 [case testCastIsinstance]
 from typing import Union

--- a/mypy/test/data/check-kwargs.test
+++ b/mypy/test/data/check-kwargs.test
@@ -102,9 +102,9 @@ f(A(), b=B())
 class A: pass
 class B: pass
 [out]
-main, line 3: Unexpected keyword argument "a"
-main, line 3: Unexpected keyword argument "b"
-main, line 4: Unexpected keyword argument "b"
+main:3: error: Unexpected keyword argument "a"
+main:3: error: Unexpected keyword argument "b"
+main:4: error: Unexpected keyword argument "b"
 
 [case testKeywordOnlyArguments]
 import typing
@@ -166,7 +166,7 @@ def f( **kwargs: 'A') -> None:
 class A: pass
 [builtins fixtures/dict.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testKwargsArgumentInFunctionBodyWithImplicitAny]
 from typing import Dict, Any
@@ -177,7 +177,7 @@ def f(**kwargs) -> None:
 class A: pass
 [builtins fixtures/dict.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testCallingFunctionThatAcceptsVarKwargs]
 import typing

--- a/mypy/test/data/check-lists.test
+++ b/mypy/test/data/check-lists.test
@@ -61,4 +61,4 @@ class B: pass
 class C: pass
 [builtins fixtures/list.py]
 [out]
-main: In function "f":
+main: note: In function "f":

--- a/mypy/test/data/check-modules.test
+++ b/mypy/test/data/check-modules.test
@@ -94,7 +94,7 @@ a = A()
 b = B()
 def f() -> None: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testImportWithinMethod]
 import typing
@@ -114,7 +114,7 @@ a = A()
 b = B()
 def f() -> None: pass
 [out]
-main: In member "f" of class "C":
+main: note: In member "f" of class "C":
 
 [case testImportWithinClassBody]
 import typing
@@ -125,7 +125,7 @@ class C:
 [file m.py]
 def f() -> None: pass
 [out]
-main: In class "C":
+main: note: In class "C":
 
 [case testImportWithinClassBody2]
 import typing
@@ -136,7 +136,7 @@ class C:
 [file m.py]
 def f() -> None: pass
 [out]
-main: In class "C":
+main: note: In class "C":
 
 [case testImportWithStub]
 import _m
@@ -204,8 +204,8 @@ else:
 import nonexistent
 None + ''
 [out]
-main, line 1: No module named 'nonexistent'
-main, line 2: Unsupported left operand type for + (None)
+main:1: error: No module named 'nonexistent'
+main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModule2]
 import m, nonexistent
@@ -215,9 +215,9 @@ m.x = ''
 [file m.py]
 x = 1
 [out]
-main, line 1: No module named 'nonexistent'
-main, line 2: Unsupported left operand type for + (None)
-main, line 4: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:1: error: No module named 'nonexistent'
+main:2: error: Unsupported left operand type for + (None)
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testTypeCheckWithUnknownModule3]
 import nonexistent, m
@@ -227,90 +227,90 @@ m.x = ''
 [file m.py]
 x = 1
 [out]
-main, line 1: No module named 'nonexistent'
-main, line 2: Unsupported left operand type for + (None)
-main, line 4: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:1: error: No module named 'nonexistent'
+main:2: error: Unsupported left operand type for + (None)
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testTypeCheckWithUnknownModule4]
 import nonexistent, another
 None + ''
 [out]
-main, line 1: No module named 'nonexistent'
-main, line 1: No module named 'another'
-main, line 2: Unsupported left operand type for + (None)
+main:1: error: No module named 'nonexistent'
+main:1: error: No module named 'another'
+main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModule5]
 import nonexistent as x
 None + ''
 [out]
-main, line 1: No module named 'nonexistent'
-main, line 2: Unsupported left operand type for + (None)
+main:1: error: No module named 'nonexistent'
+main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModuleUsingFromImport]
 from nonexistent import x
 None + ''
 [out]
-main, line 1: No module named 'nonexistent'
-main, line 2: Unsupported left operand type for + (None)
+main:1: error: No module named 'nonexistent'
+main:2: error: Unsupported left operand type for + (None)
 
 [case testTypeCheckWithUnknownModuleUsingImportStar]
 from nonexistent import *
 None + ''
 [out]
-main, line 1: No module named 'nonexistent'
-main, line 2: Unsupported left operand type for + (None)
+main:1: error: No module named 'nonexistent'
+main:2: error: Unsupported left operand type for + (None)
 
 [case testAccessingUnknownModule]
 import xyz
 xyz.foo()
 xyz()
 [out]
-main, line 1: No module named 'xyz'
+main:1: error: No module named 'xyz'
 
 [case testAccessingUnknownModule2]
 import xyz, bar
 xyz.foo()
 bar()
 [out]
-main, line 1: No module named 'xyz'
-main, line 1: No module named 'bar'
+main:1: error: No module named 'xyz'
+main:1: error: No module named 'bar'
 
 [case testAccessingUnknownModule3]
 import xyz as z
 xyz.foo()
 z()
 [out]
-main, line 1: No module named 'xyz'
-main, line 2: Name 'xyz' is not defined
+main:1: error: No module named 'xyz'
+main:2: error: Name 'xyz' is not defined
 
 [case testAccessingNameImportedFromUnknownModule]
 from xyz import y, z
 y.foo()
 z()
 [out]
-main, line 1: No module named 'xyz'
+main:1: error: No module named 'xyz'
 
 [case testAccessingNameImportedFromUnknownModule2]
 from xyz import *
 y
 [out]
-main, line 1: No module named 'xyz'
-main, line 2: Name 'y' is not defined
+main:1: error: No module named 'xyz'
+main:2: error: Name 'y' is not defined
 
 [case testAccessingNameImportedFromUnknownModule3]
 from xyz import y as z
 y
 z
 [out]
-main, line 1: No module named 'xyz'
-main, line 2: Name 'y' is not defined
+main:1: error: No module named 'xyz'
+main:2: error: Name 'y' is not defined
 
 [case testUnknownModuleRedefinition]
 import xab
 def xab(): pass
 [out]
-main, line 1: No module named 'xab'
-main, line 1: Name 'xab' already defined
+main:1: error: No module named 'xab'
+main:1: error: Name 'xab' already defined
 
 [case testAccessingUnknownModuleFromOtherModule]
 import x
@@ -320,9 +320,9 @@ x.z
 import nonexistent
 [builtins fixtures/module.py]
 [out]
-In module imported in main, line 1:
-tmp/x.py, line 1: No module named 'nonexistent'
-main, line 3: "module" has no attribute "z"
+main:1: note: In module imported here:
+tmp/x.py:1: error: No module named 'nonexistent'
+main:3: error: "module" has no attribute "z"
 
 [case testUnknownModuleImportedWithinFunction]
 def f():
@@ -330,8 +330,8 @@ def f():
 def foobar(): pass
 foobar('')
 [out]
-main, line 2: No module named 'foobar'
-main, line 4: Too many arguments for "foobar"
+main:2: error: No module named 'foobar'
+main:4: error: Too many arguments for "foobar"
 
 [case testUnknownModuleImportedWithinFunction2]
 def f():
@@ -339,8 +339,8 @@ def f():
 def x(): pass
 x('')
 [out]
-main, line 2: No module named 'foobar'
-main, line 4: Too many arguments for "x"
+main:2: error: No module named 'foobar'
+main:4: error: Too many arguments for "x"
 
 [case testRelativeImports]
 import typing
@@ -359,8 +359,8 @@ class B: pass
 x = A()
 y = B()
 [out]
-In module imported in main, line 2:
-tmp/m/a.py, line 4: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:2: note: In module imported here:
+tmp/m/a.py:4: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testRelativeImports2]
 import typing
@@ -406,11 +406,11 @@ def f(x: int = ...) -> None: pass
 [file m.pyi]
 def g(x: int = '') -> None: pass
 [out]
-In module imported in main, line 1:
-tmp/m.pyi: In function "g":
-tmp/m.pyi, line 1: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:1: note: In module imported here:
+tmp/m.pyi: note: In function "g":
+tmp/m.pyi:1: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testEllipsisDefaultArgValueInNonStub]
 def f(x: int = ...) -> None: pass # E: Incompatible types in assignment (expression has type "ellipsis", variable has type "int")
 [out]
-main: In function "f":
+main: note: In function "f":

--- a/mypy/test/data/check-multiple-inheritance.test
+++ b/mypy/test/data/check-multiple-inheritance.test
@@ -123,8 +123,8 @@ class B:
     def f(self, x: str) -> None: pass
 class C(A, B): pass
 [out]
-main: In class "C":
-main, line 6: Definition of "f" in base class "A" is incompatible with definition in base class "B"
+main: note: In class "C":
+main:6: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 
 [case testMethodNameCollisionInMultipleInheritanceWithIncompatibleSigs2]
 import typing
@@ -135,10 +135,10 @@ class B:
 class C(A, B): pass
 class D(B, A): pass
 [out]
-main: In class "C":
-main, line 6: Definition of "f" in base class "A" is incompatible with definition in base class "B"
-main: In class "D":
-main, line 7: Definition of "f" in base class "B" is incompatible with definition in base class "A"
+main: note: In class "C":
+main:6: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
+main: note: In class "D":
+main:7: error: Definition of "f" in base class "B" is incompatible with definition in base class "A"
 
 
 [case testMethodOverridingWithBothDynamicallyAndStaticallyTypedMethods]
@@ -160,8 +160,8 @@ class B:
         self.x = ''
 class C(A, B): pass
 [out]
-main: In class "C":
-main, line 8: Definition of "x" in base class "A" is incompatible with definition in base class "B"
+main: note: In class "C":
+main:8: error: Definition of "x" in base class "A" is incompatible with definition in base class "B"
 
 [case testClassVarNameOverlapInMultipleInheritanceWithInvalidTypes]
 import typing
@@ -171,8 +171,8 @@ class B:
     x = ''
 class C(A, B): pass
 [out]
-main: In class "C":
-main, line 6: Definition of "x" in base class "A" is incompatible with definition in base class "B"
+main: note: In class "C":
+main:6: error: Definition of "x" in base class "A" is incompatible with definition in base class "B"
 
 [case testMethodOverlapsWithClassVariableInMultipleInheritance]
 from typing import Callable
@@ -182,8 +182,8 @@ class B:
     f = ''
 class C(A, B): pass
 [out]
-main: In class "C":
-main, line 6: Definition of "f" in base class "A" is incompatible with definition in base class "B"
+main: note: In class "C":
+main:6: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 
 [case testMethodOverlapsWithInstanceVariableInMultipleInheritance]
 from typing import Callable
@@ -194,8 +194,8 @@ class B:
         self.f = ''
 class C(A, B): pass
 [out]
-main: In class "C":
-main, line 7: Definition of "f" in base class "A" is incompatible with definition in base class "B"
+main: note: In class "C":
+main:7: error: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 
 [case testMultipleInheritanceAndInit]
 import typing
@@ -215,8 +215,8 @@ class B:
 class C(B, A): pass
 class D(A, B): pass
 [out]
-main: In class "D":
-main, line 8: Definition of "clear" in base class "A" is incompatible with definition in base class "B"
+main: note: In class "D":
+main:8: error: Definition of "clear" in base class "A" is incompatible with definition in base class "B"
 
 
 -- Special cases

--- a/mypy/test/data/check-namedtuple.test
+++ b/mypy/test/data/check-namedtuple.test
@@ -117,7 +117,7 @@ class B(A):
         i, i = self  # E: Incompatible types in assignment (expression has type "str", \
                           variable has type "int")
 [out]
-main: In member "f" of class "B":
+main: note: In member "f" of class "B":
 
 [case testTypeReferenceToClassDerivedFromNamedTuple]
 from typing import NamedTuple
@@ -134,7 +134,7 @@ class B(A):
         i, i = self  # E: Incompatible types in assignment (expression has type "str", \
                           variable has type "int")
 [out]
-main: In member "f" of class "B":
+main: note: In member "f" of class "B":
 
 [case testNamedTupleSubtyping]
 from typing import NamedTuple, Tuple

--- a/mypy/test/data/check-overloading.test
+++ b/mypy/test/data/check-overloading.test
@@ -14,7 +14,7 @@ def f(x: 'B'):
 class A: pass
 class B: pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testTypeCheckOverloadedMethodBody]
 from typing import overload
@@ -29,7 +29,7 @@ class A:
         x = B()
 class B: pass
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 [case testCallToOverloadedFunction]
 from typing import overload
@@ -461,10 +461,10 @@ class D(A):
     @overload
     def f(self, x: str) -> str: return ''
 [out]
-main: In class "B":
-main, line 12: Signature of "f" incompatible with supertype "A"
-main: In class "C":
-main, line 17: Signature of "f" incompatible with supertype "A"
+main: note: In class "B":
+main:12: error: Signature of "f" incompatible with supertype "A"
+main: note: In class "C":
+main:17: error: Signature of "f" incompatible with supertype "A"
 
 [case testOverloadingAndDucktypeCompatibility]
 from typing import overload, _promote, builtinclass

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -14,10 +14,10 @@ class A:
 class B:
     pass
 [out]
-main: In function "f":
-main, line 4: Incompatible return value type: expected __main__.A, got __main__.B
-main: In function "g":
-main, line 6: Incompatible return value type: expected __main__.B, got __main__.A
+main: note: In function "f":
+main:4: error: Incompatible return value type: expected __main__.A, got __main__.B
+main: note: In function "g":
+main:6: error: Incompatible return value type: expected __main__.B, got __main__.A
 
 [case testReturnSubtype]
 import typing
@@ -30,8 +30,8 @@ class A:
 class B(A):
     pass
 [out]
-main: In function "f":
-main, line 3: Incompatible return value type: expected __main__.B, got __main__.A
+main: note: In function "f":
+main:3: error: Incompatible return value type: expected __main__.B, got __main__.A
 
 [case testReturnWithoutAValue]
 import typing
@@ -42,8 +42,8 @@ def g() -> None:
 class A:
     pass
 [out]
-main: In function "f":
-main, line 3: Return value expected
+main: note: In function "f":
+main:3: error: Return value expected
 
 [case testReturnNoneInFunctionReturningNone]
 import typing
@@ -52,7 +52,7 @@ def f() -> None:
 def g() -> None:
     return f()  # E: No return value expected
 [out]
-main: In function "g":
+main: note: In function "g":
 
 
 -- If statement
@@ -81,10 +81,10 @@ if b:
 class A: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 5: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 7: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 9: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 11: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:7: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:9: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:11: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 
 -- Loops
@@ -105,8 +105,8 @@ while b:
 class A: pass
 [builtins fixtures/bool.py]
 [out]
-main, line 5: Incompatible types in assignment (expression has type "bool", variable has type "A")
-main, line 7: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
+main:7: error: Incompatible types in assignment (expression has type "bool", variable has type "A")
 
 [case testForStatement]
 
@@ -120,8 +120,8 @@ else:
 class A: pass
 [builtins fixtures/list.py]
 [out]
-main, line 5: Incompatible types in assignment (expression has type "object", variable has type "A")
-main, line 7: Incompatible types in assignment (expression has type "object", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "object", variable has type "A")
+main:7: error: Incompatible types in assignment (expression has type "object", variable has type "A")
 
 [case testBreakStatement]
 import typing
@@ -158,9 +158,9 @@ class B:
 
 class C: pass
 [out]
-main, line 3: Unsupported operand types for + ("A" and "B")
-main, line 4: Result type of + incompatible in assignment
-main, line 5: Unsupported left operand type for + ("C")
+main:3: error: Unsupported operand types for + ("A" and "B")
+main:4: error: Result type of + incompatible in assignment
+main:5: error: Unsupported left operand type for + ("C")
 
 [case testMinusAssign]
 
@@ -178,9 +178,9 @@ class B:
 
 class C: pass
 [out]
-main, line 3: Unsupported operand types for - ("A" and "B")
-main, line 4: Result type of - incompatible in assignment
-main, line 5: Unsupported left operand type for - ("C")
+main:3: error: Unsupported operand types for - ("A" and "B")
+main:4: error: Result type of - incompatible in assignment
+main:5: error: Unsupported left operand type for - ("C")
 
 [case testMulAssign]
 
@@ -194,8 +194,8 @@ class A:
 
 class C: pass
 [out]
-main, line 3: Unsupported operand types for * ("A" and "A")
-main, line 4: Unsupported left operand type for * ("C")
+main:3: error: Unsupported operand types for * ("A" and "A")
+main:4: error: Unsupported left operand type for * ("C")
 
 [case testDivAssign]
 
@@ -209,8 +209,8 @@ class A:
 
 class C: pass
 [out]
-main, line 3: Unsupported operand types for / ("A" and "A")
-main, line 4: Unsupported left operand type for / ("C")
+main:3: error: Unsupported operand types for / ("A" and "A")
+main:4: error: Unsupported left operand type for / ("C")
 
 [case testPowAssign]
 
@@ -224,8 +224,8 @@ class A:
 
 class C: pass
 [out]
-main, line 3: Unsupported operand types for ** ("A" and "A")
-main, line 4: Unsupported left operand type for ** ("C")
+main:3: error: Unsupported operand types for ** ("A" and "A")
+main:4: error: Unsupported left operand type for ** ("C")
 
 [case testSubtypesInOperatorAssignment]
 
@@ -255,9 +255,9 @@ class A:
     def __floordiv__(self, x: 'C') -> 'A': pass
 class C: pass
 [out]
-main, line 3: Unsupported operand types for & ("A" and "A")
-main, line 4: Unsupported operand types for >> ("A" and "A")
-main, line 5: Unsupported operand types for // ("A" and "A")
+main:3: error: Unsupported operand types for & ("A" and "A")
+main:4: error: Unsupported operand types for >> ("A" and "A")
+main:5: error: Unsupported operand types for // ("A" and "A")
 
 [case testInplaceOperatorMethods]
 import typing
@@ -280,7 +280,7 @@ import typing
 assert None + None # Fail
 assert None
 [out]
-main, line 2: Unsupported left operand type for + (None)
+main:2: error: Unsupported left operand type for + (None)
 
 
 -- Exception handling
@@ -299,7 +299,7 @@ class A: pass
 class MyError(BaseException): pass
 [builtins fixtures/exception.py]
 [out]
-main, line 5: Exception must be derived from BaseException
+main:5: error: Exception must be derived from BaseException
 
 [case testRaiseClassobject]
 import typing
@@ -345,8 +345,8 @@ finally:
     c = object() # type: A # Fail
 class A: pass
 [out]
-main, line 3: Incompatible types in assignment (expression has type "object", variable has type "A")
-main, line 5: Incompatible types in assignment (expression has type "object", variable has type "A")
+main:3: error: Incompatible types in assignment (expression has type "object", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "object", variable has type "A")
 
 [case testSimpleTryExcept]
 
@@ -360,7 +360,7 @@ class A: pass
 class B: pass
 [builtins fixtures/exception.py]
 [out]
-main, line 7: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
+main:7: error: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
 
 [case testTypeErrorInBlock]
 
@@ -371,8 +371,8 @@ while object:
 class A: pass
 class B: pass
 [out]
-main, line 4: Incompatible types in assignment (expression has type "object", variable has type "A")
-main, line 5: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "object", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testTypeErrorInvolvingBaseException]
 
@@ -385,10 +385,10 @@ x = BaseException()
 class A: pass
 [builtins fixtures/exception.py]
 [out]
-main, line 3: Incompatible types in assignment (expression has type "BaseException", variable has type "A")
-main, line 4: Incompatible types in assignment (expression has type "object", variable has type "A")
-main, line 5: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
-main, line 6: Incompatible types in assignment (expression has type "A", variable has type "BaseException")
+main:3: error: Incompatible types in assignment (expression has type "BaseException", variable has type "A")
+main:4: error: Incompatible types in assignment (expression has type "object", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
+main:6: error: Incompatible types in assignment (expression has type "A", variable has type "BaseException")
 
 [case testSimpleTryExcept2]
 import typing
@@ -399,7 +399,7 @@ except BaseException as e:
   e = BaseException()
 [builtins fixtures/exception.py]
 [out]
-main, line 5: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
+main:5: error: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
 
 [case testBaseClassAsExceptionTypeInExcept]
 import typing
@@ -411,7 +411,7 @@ except Err as e:
 class Err(BaseException): pass
 [builtins fixtures/exception.py]
 [out]
-main, line 5: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
+main:5: error: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
 
 [case testMultipleExceptHandlers]
 import typing
@@ -425,7 +425,7 @@ except Err as f:
 class Err(BaseException): pass
 [builtins fixtures/exception.py]
 [out]
-main, line 7: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
+main:7: error: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
 
 [case testTryExceptStatement]
 import typing
@@ -442,9 +442,9 @@ class B: pass
 class Err(BaseException): pass
 [builtins fixtures/exception.py]
 [out]
-main, line 3: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 5: Incompatible types in assignment (expression has type "A", variable has type "BaseException")
-main, line 8: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
+main:3: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "A", variable has type "BaseException")
+main:8: error: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
 
 [case testTryExceptWithinFunction]
 import typing
@@ -459,9 +459,9 @@ def f() -> None:
 class Err(BaseException): pass
 [builtins fixtures/exception.py]
 [out]
-main: In function "f":
-main, line 5: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
-main, line 8: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
+main: note: In function "f":
+main:5: error: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
+main:8: error: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
 
 [case testTryWithElse]
 import typing
@@ -593,7 +593,7 @@ def f() -> Iterator[int]:
     yield '' # E: Incompatible types in yield (actual type "str", expected type "int")
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testYieldInFunctionReturningAny]
 from typing import Any
@@ -606,7 +606,7 @@ from typing import Callable
 def f() -> Callable[[], None]:
     yield object() # E: Iterator function return type expected for "yield"
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testYieldInDynamicallyTypedFunction]
 import typing
@@ -619,7 +619,7 @@ def f() -> int:
     yield 1 # E: Iterator function return type expected for "yield"
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testTypeInferenceContextAndYield]
 from typing import List, Iterator
@@ -628,7 +628,7 @@ def f() -> 'Iterator[List[int]]':
     yield [object()] # E: List item 0 has incompatible type "object"
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testYieldAndReturnWithoutValue]
 from typing import Iterator
@@ -660,7 +660,7 @@ def f() -> Iterator[str]:
     yield from g()
     yield from h()  # E: Incompatible types in "yield from" (actual type "int", expected type "str")
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testYieldFromAppliedToAny]
 from typing import Any
@@ -677,7 +677,7 @@ def g() -> Iterator[int]:
 def f() -> Callable[[], None]:
     yield from g()  # E: Iterable function return type expected for "yield from"
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testYieldFromNotIterableReturnType]
 from typing import Iterator
@@ -686,7 +686,7 @@ def g() -> Iterator[int]:
 def f() -> int:
     yield from g()  # E: Iterable function return type expected for "yield from"
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testYieldFromNotAppliedIterator]
 from typing import Iterator
@@ -695,7 +695,7 @@ def g() -> int:
 def f() -> Iterator[int]:
     yield from g()  # E: "yield from" can't be applied to "int"
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testYieldFromCheckIncompatibleTypesTwoIterables]
 from typing import List, Iterator
@@ -706,13 +706,13 @@ def f() -> Iterator[List[int]]:
     yield from [1, 2, 3]  # E: Incompatible types in "yield from" (actual type "int", expected type List[int])
 [builtins fixtures/for.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testYieldFromNotAppliedToNothing]
 def h():
     yield from  # E: Parse error before end of line
 [out]
-main: In function "h":
+main: note: In function "h":
 
 [case testYieldFromAndYieldTogether]
 from typing import Iterator
@@ -841,7 +841,7 @@ def f() -> None:
     x = y = 1   # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [builtins fixtures/primitives.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testChainedAssignmentWithType]
 
@@ -915,8 +915,8 @@ def f() -> None:
 class A(): pass
 class B(): pass
 [out]
-main: In function "f":
-main, line 5: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In function "f":
+main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testTypeOfNonlocalUsed]
 import typing
@@ -929,8 +929,8 @@ def f() -> None:
 class A(): pass
 class B(): pass
 [out]
-main: In function "g":
-main, line 6: Incompatible types in assignment (expression has type "B", variable has type "A")
+main: note: In function "g":
+main:6: error: Incompatible types in assignment (expression has type "B", variable has type "A")
 
 [case testTypeOfOuterMostNonlocalUsed]
 import typing
@@ -946,5 +946,5 @@ def f() -> None:
 class A(): pass
 class B(): pass
 [out]
-main: In function "h":
-main, line 8: Incompatible types in assignment (expression has type "A", variable has type "B")
+main: note: In function "h":
+main:8: error: Incompatible types in assignment (expression has type "A", variable has type "B")

--- a/mypy/test/data/check-super.test
+++ b/mypy/test/data/check-super.test
@@ -16,7 +16,7 @@ class A(B):
     a = super().g() # E: "g" undefined in superclass
     b = super().f()
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 [case testAccessingSuperTypeMethodWithArgs]
 from typing import Any
@@ -30,7 +30,7 @@ class A(B):
     self.f(b)
     self.f(a)
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 [case testAccessingSuperInit]
 import typing
@@ -42,7 +42,7 @@ class A(B):
     super().__init__()       # E: Too few arguments for "__init__" of "B"
     super().__init__(A())
 [out]
-main: In member "__init__" of class "A":
+main: note: In member "__init__" of class "A":
 
 [case testAccessingSuperMemberWithDeepHierarchy]
 import typing
@@ -54,7 +54,7 @@ class A(B):
     super().g() # E: "g" undefined in superclass
     super().f()
 [out]
-main: In member "f" of class "A":
+main: note: In member "f" of class "A":
 
 [case testAssignToBaseClassMethod]
 import typing
@@ -64,5 +64,5 @@ class B(A):
     def g(self) -> None:
         super().f = None
 [out]
-main: In function "g":
-main, line 6: Invalid assignment target
+main: note: In function "g":
+main:6: error: Invalid assignment target

--- a/mypy/test/data/check-tuples.test
+++ b/mypy/test/data/check-tuples.test
@@ -253,9 +253,9 @@ class A: pass
 class B: pass
 [builtins fixtures/tuple.py]
 [out]
-main, line 4: Incompatible types in assignment (expression has type "A", variable has type "B")
-main, line 5: Incompatible types in assignment (expression has type "B", variable has type "A")
-main, line 5: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:4: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+main:5: error: Incompatible types in assignment (expression has type "B", variable has type "A")
+main:5: error: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 [case testSubtypingInMultipleAssignment]
 
@@ -431,9 +431,9 @@ na = a  # E
 class A: pass
 [builtins fixtures/list.py]
 [out]
-main, line 6: List item 0 has incompatible type "A"
-main, line 6: List item 1 has incompatible type "A"
-main, line 9: Incompatible types in assignment (expression has type "A", variable has type List[A])
+main:6: error: List item 0 has incompatible type "A"
+main:6: error: List item 1 has incompatible type "A"
+main:9: error: Incompatible types in assignment (expression has type "A", variable has type List[A])
 
 [case testAssignmentToStarFromTupleInference]
 from typing import List
@@ -502,7 +502,7 @@ class A: pass
 class B: pass
 class C: pass
 [out]
-main, line 7: Incompatible types in assignment (expression has type "C", variable has type "B")
+main:7: error: Incompatible types in assignment (expression has type "C", variable has type "B")
 
 [case testNestedTupleAssignment2]
 
@@ -525,13 +525,13 @@ class A: pass
 class B: pass
 class C: pass
 [out]
-main, line 8: Incompatible types in assignment (expression has type "B", variable has type "C")
-main, line 10: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
-main, line 11: Incompatible types in assignment (expression has type "Tuple[A, A, A]", variable has type "Tuple[A, B]")
-main, line 12: Incompatible types in assignment (expression has type "A", variable has type "Tuple[A, B]")
-main, line 13: Need more than 2 values to unpack (3 expected)
-main, line 14: Too many values to unpack (1 expected, 2 provided)
-main, line 15: Incompatible types in assignment (expression has type "Tuple[A, B]", variable has type "A")
+main:8: error: Incompatible types in assignment (expression has type "B", variable has type "C")
+main:10: error: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "Tuple[A, B]")
+main:11: error: Incompatible types in assignment (expression has type "Tuple[A, A, A]", variable has type "Tuple[A, B]")
+main:12: error: Incompatible types in assignment (expression has type "A", variable has type "Tuple[A, B]")
+main:13: error: Need more than 2 values to unpack (3 expected)
+main:14: error: Too many values to unpack (1 expected, 2 provided)
+main:15: error: Incompatible types in assignment (expression has type "Tuple[A, B]", variable has type "A")
 
 
 -- Error messages
@@ -562,7 +562,7 @@ class LongTypeName:
     def __add__(self, x: 'LongTypeName') -> 'LongTypeName': pass
 [builtins fixtures/tuple.py]
 [out]
-main, line 3: Unsupported operand types for + ("LongTypeName" and tuple(length 7))
+main:3: error: Unsupported operand types for + ("LongTypeName" and tuple(length 7))
 
 
 -- Tuple methods
@@ -653,7 +653,7 @@ class A(Tuple[int, str]):
         b, a = self  # Error
         self.f('')   # Error
 [out]
-main: In member "f" of class "A":
-main, line 6: Incompatible types in assignment (expression has type "int", variable has type "str")
-main, line 6: Incompatible types in assignment (expression has type "str", variable has type "int")
-main, line 7: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+main: note: In member "f" of class "A":
+main:6: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:7: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"

--- a/mypy/test/data/check-type-checks.test
+++ b/mypy/test/data/check-type-checks.test
@@ -23,7 +23,7 @@ def f(x: object, n: int, s: str) -> None:
     n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testSimpleIsinstance3]
 
@@ -39,7 +39,7 @@ class A:
         n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.py]
 [out]
-main: In class "A":
+main: note: In class "A":
 
 [case testMultipleIsinstanceTests]
 import typing
@@ -54,7 +54,7 @@ def f(x: object, a: A, b: B, c: int) -> None:
         c = x # E: Incompatible types in assignment (expression has type "A", variable has type "int")
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testMultipleIsinstanceTests2]
 import typing
@@ -72,7 +72,7 @@ def f(x: object, y: object, n: int, s: str) -> None:
         n = x
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testIsinstanceAndElif]
 import typing
@@ -90,7 +90,7 @@ def f(x: object, n: int, s: str) -> None:
     n = x # E: Incompatible types in assignment (expression has type "object", variable has type "int")
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testIsinstanceAndAnyType]
 from typing import Any
@@ -102,7 +102,7 @@ def f(x: Any, n: int, s: str) -> None:
     s = x
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testIsinstanceAndGenericType]
 from typing import TypeVar, Generic
@@ -117,4 +117,4 @@ def f(x: object) -> None:
     x.g() # E: "object" has no attribute "g"
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":

--- a/mypy/test/data/check-typevar-values.test
+++ b/mypy/test/data/check-typevar-values.test
@@ -69,10 +69,10 @@ def f(x: AB) -> AB:
 def g(x: AB) -> AB:
     return x.g() # Error
 [out]
-main: In function "f":
-main, line 10: Incompatible return value type: expected __main__.B*, got __main__.A
-main: In function "g":
-main, line 12: Incompatible return value type: expected __main__.A*, got __main__.B
+main: note: In function "f":
+main:10: error: Incompatible return value type: expected __main__.B*, got __main__.A
+main: note: In function "g":
+main:12: error: Incompatible return value type: expected __main__.A*, got __main__.B
 
 [case testTypeInferenceAndTypeVarValues]
 from typing import TypeVar
@@ -90,7 +90,7 @@ def f(x: AB) -> AB:
     else:
         return y.g() # E: Incompatible return value type: expected __main__.A*, got __main__.B
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testTypeDeclaredBasedOnTypeVarWithValues]
 from typing import TypeVar
@@ -103,7 +103,7 @@ def f(x: T) -> T:
     a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
     b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testIsinstanceAndTypeVarValues]
 from typing import TypeVar
@@ -120,7 +120,7 @@ def h(x: T) -> T:
     return x
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "h":
+main: note: In function "h":
 
 [case testIsinstanceAndTypeVarValues2]
 from typing import TypeVar
@@ -138,7 +138,7 @@ def g(x: T) -> T:
     return x
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testIsinstanceAndTypeVarValues3]
 from typing import TypeVar
@@ -162,7 +162,7 @@ def f(x: T) -> T:
     return y # E: Incompatible return value type: expected builtins.str*, got builtins.object
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testIsinstanceAndTypeVarValues5]
 from typing import TypeVar
@@ -175,7 +175,7 @@ def f(x: T) -> T:
     return y # E: Incompatible return value type: expected builtins.int*, got builtins.object
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testIsinstanceWithUserDefinedTypeAndTypeVarValues]
 from typing import TypeVar
@@ -199,7 +199,7 @@ def g(x: S) -> None:
         x = y
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testIsinstanceWithUserDefinedTypeAndTypeVarValues2]
 from typing import TypeVar
@@ -218,7 +218,7 @@ def f(x: T) -> None:
         x = S() # E: Incompatible types in assignment (expression has type "S", variable has type "int")
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testTypeVarValuesAndNestedCalls]
 from typing import TypeVar
@@ -263,10 +263,10 @@ def g(x: Y) -> None:
 def h(x: Z) -> None:
     a = None  # type: D[Z]
 [out]
-main: In function "g":
-main, line 11: Invalid type argument value for "D"
-main: In function "h":
-main, line 13: Type variable "Z" not valid as type argument value for "D"
+main: note: In function "g":
+main:11: error: Invalid type argument value for "D"
+main: note: In function "h":
+main:13: error: Type variable "Z" not valid as type argument value for "D"
 
 [case testGenericTypeWithTypevarValuesAndSubtypePromotion]
 from typing import TypeVar, Generic
@@ -298,7 +298,7 @@ class C(Generic[X]):
         x.g(1) # E: Argument 1 to "g" of "B" has incompatible type "int"; expected "str"
         x.h(1) # E: Argument 1 to "h" of "A" has incompatible type "int"; expected "str"
 [out]
-main: In member "f" of class "C":
+main: note: In member "f" of class "C":
 
 [case testAttributeInGenericTypeWithTypevarValues1]
 from typing import TypeVar, Generic
@@ -309,7 +309,7 @@ class C(Generic[X]):
         self.x = x
         self.x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 [out]
-main: In member "f" of class "C":
+main: note: In member "f" of class "C":
 
 [case testAttributeInGenericTypeWithTypevarValues2]
 from typing import TypeVar, Generic
@@ -343,9 +343,9 @@ class C(Generic[X, Y]):
     def f(self, x: X, y: Y) -> None:
         x.f(y)
 [out]
-main: In member "f" of class "C":
-main, line 10: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
-main, line 10: Argument 1 to "f" of "B" has incompatible type "int"; expected "str"
+main: note: In member "f" of class "C":
+main:10: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
+main:10: error: Argument 1 to "f" of "B" has incompatible type "int"; expected "str"
 
 [case testMultipleClassTypevarsWithValues2]
 from typing import TypeVar, Generic
@@ -384,12 +384,12 @@ def f(x: X, y: Y, z: int) -> None:
     z = y # Error
     y.foo # Error
 [out]
-main: In function "f":
-main, line 8: Type argument 1 of "C" has incompatible value "X"
-main, line 9: Incompatible types in assignment (expression has type "X", variable has type "int")
-main, line 10: Incompatible types in assignment (expression has type "str", variable has type "int")
-main, line 11: "int" has no attribute "foo"
-main, line 11: "str" has no attribute "foo"
+main: note: In function "f":
+main:8: error: Type argument 1 of "C" has incompatible value "X"
+main:9: error: Incompatible types in assignment (expression has type "X", variable has type "int")
+main:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:11: error: "int" has no attribute "foo"
+main:11: error: "str" has no attribute "foo"
 
 [case testTypeVarWithValueInferredFromObjectReturnTypeContext]
 from typing import TypeVar
@@ -413,8 +413,8 @@ def g(x: T) -> T: pass
 c(g(''))
 c(g(1))
 [out]
-main, line 6: Argument 1 to "c" has incompatible type "str"; expected "ss"
-main, line 7: Argument 1 to "c" has incompatible type "int"; expected "ss"
+main:6: error: Argument 1 to "c" has incompatible type "str"; expected "ss"
+main:7: error: Argument 1 to "c" has incompatible type "int"; expected "ss"
 
 
 -- Special cases
@@ -436,7 +436,7 @@ class C(A[str]):
     def f(self) -> int: # E: Return type of "f" incompatible with supertype "A"
         pass
 [out]
-main: In class "C":
+main: note: In class "C":
 
 [case testDefaultArgumentValueInGenericClassWithTypevarValues]
 from typing import TypeVar, Generic
@@ -462,6 +462,6 @@ def g(x: int) -> int: return x
 @overload
 def g(x: str) -> str: return x
 [out]
-main: In function "f":
-main, line 7: Incompatible types in assignment (expression has type "object", variable has type "int")
-main, line 7: Incompatible types in assignment (expression has type "object", variable has type "str")
+main: note: In function "f":
+main:7: error: Incompatible types in assignment (expression has type "object", variable has type "int")
+main:7: error: Incompatible types in assignment (expression has type "object", variable has type "str")

--- a/mypy/test/data/check-unions.test
+++ b/mypy/test/data/check-unions.test
@@ -33,7 +33,7 @@ def f(x: Union[int, str]) -> None:
         z = x # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/isinstance.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 
 [case testUnionAttributeAccess]

--- a/mypy/test/data/check-unreachable-code.test
+++ b/mypy/test/data/check-unreachable-code.test
@@ -66,8 +66,8 @@ import typing
 x = 1
 x = 'a'
 [out]
-In module imported in main, line 9:
-tmp/m.py, line 3: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:9: note: In module imported here:
+tmp/m.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testNegatedMypyConditional]
 import typing

--- a/mypy/test/data/check-unsupported.test
+++ b/mypy/test/data/check-unsupported.test
@@ -11,5 +11,5 @@ def g(): pass
 @d
 def g(x): pass
 [out]
-main, line 5: Name 'f' already defined
-main, line 7: Name 'g' already defined
+main:5: error: Name 'f' already defined
+main:7: error: Name 'g' already defined

--- a/mypy/test/data/check-varargs.test
+++ b/mypy/test/data/check-varargs.test
@@ -19,7 +19,7 @@ class B: pass
 class C: pass
 [builtins fixtures/list.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 
 -- Calling varargs function
@@ -179,7 +179,7 @@ class A: pass
 class B: pass
 [builtins fixtures/list.py]
 [out]
-main, line 7: Argument 1 to "f" has incompatible type List[A]; expected "B"
+main:7: error: Argument 1 to "f" has incompatible type List[A]; expected "B"
 
 [case testCallingWithTupleVarArgs]
 
@@ -248,13 +248,13 @@ class A: pass
 class B: pass
 [builtins fixtures/list.py]
 [out]
-main, line 3: Argument 1 to "f" has incompatible type List[A]; expected "B"
-main, line 4: Argument 2 to "f" has incompatible type List[A]; expected "B"
-main, line 5: Argument 1 to "f" has incompatible type "B"; expected "A"
-main, line 6: Argument 2 to "f" has incompatible type "A"; expected "B"
-main, line 7: Argument 3 to "f" has incompatible type List[A]; expected "B"
-main, line 8: Argument 1 to "f" has incompatible type "B"; expected "A"
-main, line 9: Argument 1 to "g" has incompatible type List[B]; expected "A"
+main:3: error: Argument 1 to "f" has incompatible type List[A]; expected "B"
+main:4: error: Argument 2 to "f" has incompatible type List[A]; expected "B"
+main:5: error: Argument 1 to "f" has incompatible type "B"; expected "A"
+main:6: error: Argument 2 to "f" has incompatible type "A"; expected "B"
+main:7: error: Argument 3 to "f" has incompatible type List[A]; expected "B"
+main:8: error: Argument 1 to "f" has incompatible type "B"; expected "A"
+main:9: error: Argument 1 to "g" has incompatible type List[B]; expected "A"
 
 [case testCallingVarArgsFunctionWithTupleVarArgs]
 
@@ -303,8 +303,8 @@ def g(a: 'A', *b: 'A') -> None: pass
 class A: pass
 [builtins fixtures/list.py]
 [out]
-main, line 3: Too many arguments for "f"
-main, line 4: Too many arguments for "f"
+main:3: error: Too many arguments for "f"
+main:4: error: Too many arguments for "f"
 
 [case testListVarArgsAndSubtyping]
 from typing import List
@@ -347,26 +347,26 @@ class A: pass
 class B: pass
 [builtins fixtures/list.py]
 [out]
-main, line 3: Too few arguments for "f"
-main, line 4: Argument 2 to "f" has incompatible type List[A]; expected "B"
-main, line 5: Argument 3 to "f" has incompatible type List[A]; expected "B"
-main, line 6: Argument 1 to "f" has incompatible type "Tuple[A, A, B]"; expected "B"
+main:3: error: Too few arguments for "f"
+main:4: error: Argument 2 to "f" has incompatible type List[A]; expected "B"
+main:5: error: Argument 3 to "f" has incompatible type List[A]; expected "B"
+main:6: error: Argument 1 to "f" has incompatible type "Tuple[A, A, B]"; expected "B"
 
 [case testVarArgsAfterKeywordArgInCall1]
 def f(x: int, y: str) -> None: pass
 f(x=1, *[2])
 [builtins fixtures/list.py]
 [out]
-main, line 2: "f" gets multiple values for keyword argument "x"
-main, line 2: Argument 2 to "f" has incompatible type List[int]; expected "str"
+main:2: error: "f" gets multiple values for keyword argument "x"
+main:2: error: Argument 2 to "f" has incompatible type List[int]; expected "str"
 
 [case testVarArgsAfterKeywordArgInCall2]
 def f(x: int, y: str) -> None: pass
 f(y='x', *[1])
 [builtins fixtures/list.py]
 [out]
-main, line 2: "f" gets multiple values for keyword argument "y"
-main, line 2: Argument 2 to "f" has incompatible type List[int]; expected "str"
+main:2: error: "f" gets multiple values for keyword argument "y"
+main:2: error: Argument 2 to "f" has incompatible type List[int]; expected "str"
 
 [case testVarArgsAfterKeywordArgInCall3]
 def f(x: int, y: str) -> None: pass
@@ -458,13 +458,13 @@ class A: pass
 class B: pass
 [builtins fixtures/list.py]
 [out]
-main, line 6: Argument 1 to "f" has incompatible type List[A]; expected "B"
-main, line 7: Argument 1 to "f" has incompatible type List[A]; expected "B"
-main, line 8: Argument 1 to "f" has incompatible type "B"; expected "A"
-main, line 9: Argument 2 to "f" has incompatible type List[A]; expected "B"
-main, line 10: Argument 3 to "f" has incompatible type List[A]; expected "B"
-main, line 11: List or tuple expected as variable arguments
-main, line 12: List or tuple expected as variable arguments
+main:6: error: Argument 1 to "f" has incompatible type List[A]; expected "B"
+main:7: error: Argument 1 to "f" has incompatible type List[A]; expected "B"
+main:8: error: Argument 1 to "f" has incompatible type "B"; expected "A"
+main:9: error: Argument 2 to "f" has incompatible type List[A]; expected "B"
+main:10: error: Argument 3 to "f" has incompatible type List[A]; expected "B"
+main:11: error: List or tuple expected as variable arguments
+main:12: error: List or tuple expected as variable arguments
 
 [case testCallerVarArgsTupleWithTypeInference]
 from typing import TypeVar, Tuple
@@ -511,11 +511,11 @@ class A: pass
 class B: pass
 [builtins fixtures/list.py]
 [out]
-main, line 9: Incompatible types in assignment (expression has type List[A], variable has type "A")
-main, line 9: Incompatible types in assignment (expression has type List[None], variable has type List[A])
-main, line 10: Incompatible types in assignment (expression has type List[None], variable has type "A")
-main, line 11: Argument 1 to "f" of "G" has incompatible type List[A]; expected "B"
-main, line 11: Incompatible types in assignment (expression has type List[None], variable has type List[A])
+main:9: error: Incompatible types in assignment (expression has type List[A], variable has type "A")
+main:9: error: Incompatible types in assignment (expression has type List[None], variable has type List[A])
+main:10: error: Incompatible types in assignment (expression has type List[None], variable has type "A")
+main:11: error: Argument 1 to "f" of "G" has incompatible type List[A]; expected "B"
+main:11: error: Incompatible types in assignment (expression has type List[None], variable has type List[A])
 
 
 -- Comment signatures

--- a/mypy/test/data/parse-errors.test
+++ b/mypy/test/data/parse-errors.test
@@ -12,271 +12,271 @@
 def f()
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before end of line
-file: At top level:
-file, line 2: Inconsistent indentation
+file: note: In function "f":
+file:1: error: Parse error before end of line
+file: note: At top level:
+file:2: error: Inconsistent indentation
 
 [case testMissingIndent]
 if x:
 1
 [out]
-file, line 2: Expected an indented block
+file:2: error: Expected an indented block
 
 [case testUnexpectedIndent]
 1
  2
 [out]
-file, line 2: Inconsistent indentation
+file:2: error: Inconsistent indentation
 
 [case testInconsistentIndent]
 if x:
   1
    1
 [out]
-file, line 3: Inconsistent indentation
+file:3: error: Inconsistent indentation
 
 [case testInconsistentIndent]
 if x:
    1
   1
 [out]
-file, line 3: Inconsistent indentation
+file:3: error: Inconsistent indentation
 
 [case testInvalidBinaryOp]
 1>
 a*
 a+1*
 [out]
-file, line 1: Parse error before end of line
-file, line 2: Parse error before end of line
-file, line 3: Parse error before end of line
+file:1: error: Parse error before end of line
+file:2: error: Parse error before end of line
+file:3: error: Parse error before end of line
 
 [case testDoubleStar]
 **a
 [out]
-file, line 1: Parse error before **
+file:1: error: Parse error before **
 
 [case testInvalidSuperClass]
 class A(C[):
   pass
 [out]
-file: In class "A":
-file, line 1: Parse error before )
-file, line 2: Parse error before end of file
+file: note: In class "A":
+file:1: error: Parse error before )
+file:2: error: Parse error before end of file
 
 [case testMissingSuperClass]
 class A(:
   pass
 [out]
-file: In class "A":
-file, line 1: Parse error before :
-file, line 2: Parse error before end of file
+file: note: In class "A":
+file:1: error: Parse error before :
+file:2: error: Parse error before end of file
 
 [case testUnexpectedEof]
 if 1:
 [out]
-file, line 1: Expected an indented block
+file:1: error: Expected an indented block
 
 [case testInvalidKeywordArguments1]
 f(x=y, z)
 [out]
-file, line 1: Parse error before "z"
+file:1: error: Parse error before "z"
 
 [case testInvalidKeywordArguments2]
 f(**x, y=z)
 [out]
-file, line 1: Parse error before "y"
+file:1: error: Parse error before "y"
 
 [case testInvalidKeywordArguments3]
 f(**x, y)
 [out]
-file, line 1: Parse error before "y"
+file:1: error: Parse error before "y"
 
 [case testInvalidVarArgs]
 f(*x, y)
 [out]
-file, line 1: Parse error before "y"
+file:1: error: Parse error before "y"
 
 [case testInvalidBareAsteriskAndVarArgs2]
 def f(*x: A, *) -> None: pass
 [out]
-file: In function "f":
-file, line 1: Parse error before )
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before )
+file:1: error: Parse error before end of line
 
 [case testInvalidBareAsteriskAndVarArgs3]
 def f(*, *x: A) -> None: pass
 [out]
-file: In function "f":
-file, line 1: Parse error before *
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before *
+file:1: error: Parse error before end of line
 
 [case testInvalidBareAsteriskAndVarArgs4]
 def f(*, **x: A) -> None: pass
 [out]
-file: In function "f":
-file, line 1: Parse error before **
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before **
+file:1: error: Parse error before end of line
 
 [case testInvalidBareAsterisk1]
 def f(*) -> None: pass
 [out]
-file: In function "f":
-file, line 1: Parse error before )
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before )
+file:1: error: Parse error before end of line
 
 [case testInvalidBareAsterisk2]
 def f(x, *) -> None: pass
 [out]
-file: In function "f":
-file, line 1: Parse error before )
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before )
+file:1: error: Parse error before end of line
 
 [case testInvalidFuncDefArgs1]
 def f(x = y, x): pass
 [out]
-file: In function "f":
-file, line 1: Invalid argument list
+file: note: In function "f":
+file:1: error: Invalid argument list
 
 [case testInvalidFuncDefArgs3]
 def f(**x, y):
    pass
 [out]
-file: In function "f":
-file, line 1: Invalid argument list
+file: note: In function "f":
+file:1: error: Invalid argument list
 
 [case testInvalidFuncDefArgs4]
 def f(**x, y=x):
     pass
 [out]
-file: In function "f":
-file, line 1: Invalid argument list
+file: note: In function "f":
+file:1: error: Invalid argument list
 
 [case testInvalidStringLiteralType]
 def f(x:
      'A['
      ) -> None: pass
 [out]
-file: In function "f":
-file, line 2: Parse error before end of line
-file, line 3: Parse error before end of line
+file: note: In function "f":
+file:2: error: Parse error before end of line
+file:3: error: Parse error before end of line
 
 [case testInvalidStringLiteralType2]
 def f(x:
       'A B'
       ) -> None: pass
 [out]
-file: In function "f":
-file, line 2: Parse error before "B"
-file, line 3: Parse error before end of line
+file: note: In function "f":
+file:2: error: Parse error before "B"
+file:3: error: Parse error before end of line
 
 [case testInvalidTypeComment]
 0
 x = 0 # type: A A
 [out]
-file, line 2: Parse error before "A"
+file:2: error: Parse error before "A"
 
 [case testInvalidTypeComment2]
 0
 x = 0 # type: A[
 [out]
-file, line 2: Parse error before end of line
+file:2: error: Parse error before end of line
 
 [case testInvalidTypeComment3]
 0
 x = 0 # type:
 [out]
-file, line 2: Empty type annotation
+file:2: error: Empty type annotation
 
 [case testInvalidTypeComment4]
 0
 x = 0 # type: *
 [out]
-file, line 2: Parse error before end of line
+file:2: error: Parse error before end of line
 
 [case testInvalidMultilineLiteralType]
 def f() -> "A\nB": pass
 [out]
-file: In function "f":
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before end of line
 
 [case testInvalidMetaclass]
 class A(metaclass=1): pass
 [out]
-file: In class "A":
-file, line 1: Parse error before numeric literal
-file, line 1: Parse error before end of file
+file: note: In class "A":
+file:1: error: Parse error before numeric literal
+file:1: error: Parse error before end of file
 
 [case testInvalidSignatureInComment1]
 def f(): # type: x
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before "x"
+file: note: In function "f":
+file:1: error: Parse error before "x"
 
 [case testInvalidSignatureInComment2]
 def f(): # type:
   pass
 [out]
-file: In function "f":
-file, line 1: Empty type annotation
+file: note: In function "f":
+file:1: error: Empty type annotation
 
 [case testInvalidSignatureInComment3]
 def f(): # type: (
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before end of line
 
 [case testInvalidSignatureInComment4]
 def f(): # type: (.
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before .
+file: note: In function "f":
+file:1: error: Parse error before .
 
 [case testInvalidSignatureInComment5]
 def f(): # type: (x
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before end of line
 
 [case testInvalidSignatureInComment6]
 def f(): # type: (x)
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before end of line
 
 [case testInvalidSignatureInComment7]
 def f(): # type: (x) -
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before -
+file: note: In function "f":
+file:1: error: Parse error before -
 
 [case testInvalidSignatureInComment8]
 def f(): # type: (x) ->
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before end of line
+file: note: In function "f":
+file:1: error: Parse error before end of line
 
 [case testInvalidSignatureInComment9]
 def f(): # type: (x) -> .
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before .
+file: note: In function "f":
+file:1: error: Parse error before .
 
 [case testInvalidSignatureInComment10]
 def f(): # type: (x) -> x x
   pass
 [out]
-file: In function "f":
-file, line 1: Parse error before "x"
+file: note: In function "f":
+file:1: error: Parse error before "x"
 
 [case testDuplicateSignatures1]
 def f() -> None: # type: () -> None
@@ -284,15 +284,15 @@ def f() -> None: # type: () -> None
 def f(): # type: () -> None
     pass
 [out]
-file: In function "f":
-file, line 1: Function has duplicate type signatures
+file: note: In function "f":
+file:1: error: Function has duplicate type signatures
 
 [case testDuplicateSignatures2]
 def f(x, y: Z): # type: (x, y) -> z
   pass
 [out]
-file: In function "f":
-file, line 1: Function has duplicate type signatures
+file: note: In function "f":
+file:1: error: Function has duplicate type signatures
 
 [case testCommentFunctionAnnotationVarArgMispatch]
 def f(x): # type: (*X) -> Y
@@ -300,10 +300,10 @@ def f(x): # type: (*X) -> Y
 def g(*x): # type: (X) -> Y
     pass
 [out]
-file: In function "f":
-file, line 1: Inconsistent use of '*' in function signature
-file: In function "g":
-file, line 3: Inconsistent use of '*' in function signature
+file: note: In function "f":
+file:1: error: Inconsistent use of '*' in function signature
+file: note: In function "g":
+file:3: error: Inconsistent use of '*' in function signature
 
 [case testCommentFunctionAnnotationVarArgMispatch2]
 def f(*x, **y): # type: (**X, *Y) -> Z
@@ -311,136 +311,136 @@ def f(*x, **y): # type: (**X, *Y) -> Z
 def g(*x, **y): # type: (*X, *Y) -> Z
     pass
 [out]
-file: In function "f":
-file, line 1: Inconsistent use of '*' in function signature
-file, line 1: Inconsistent use of '**' in function signature
-file: In function "g":
-file, line 3: Inconsistent use of '*' in function signature
-file, line 3: Inconsistent use of '**' in function signature
+file: note: In function "f":
+file:1: error: Inconsistent use of '*' in function signature
+file:1: error: Inconsistent use of '**' in function signature
+file: note: In function "g":
+file:3: error: Inconsistent use of '*' in function signature
+file:3: error: Inconsistent use of '**' in function signature
 
 [case testPrintStatementInPython3]
 print 1
 [out]
-file, line 1: Parse error before numeric literal
+file:1: error: Parse error before numeric literal
 
 [case testInvalidConditionInConditionalExpression]
 1 if 2, 3 else 4
 [out]
-file, line 1: Parse error before ,
+file:1: error: Parse error before ,
 
 [case testInvalidConditionInConditionalExpression2]
 1 if x for y in z else 4
 [out]
-file, line 1: Parse error before "for"
+file:1: error: Parse error before "for"
 
 [case testInvalidConditionInConditionalExpression2]
 1 if x else for y in z
 [out]
-file, line 1: Parse error before "for"
+file:1: error: Parse error before "for"
 
 [case testYieldFromNotRightParameter]
 def f():
     yield from
 [out]
-file: In function "f":
-file, line 2: Parse error before end of line
+file: note: In function "f":
+file:2: error: Parse error before end of line
 
 [case testYieldFromAfterReturn]
 def f():
     return yield from h()
 [out]
-file: In function "f":
-file, line 2: Parse error before "yield"
+file: note: In function "f":
+file:2: error: Parse error before "yield"
 
 [case testImportDotModule]
 import .x
 [out]
-file, line 1: Parse error before .
+file:1: error: Parse error before .
 
 [case testImportDot]
 import .
 [out]
-file, line 1: Parse error before .
+file:1: error: Parse error before .
 
 [case testInvalidFunctionName]
 def while(): pass
 [out]
-file, line 1: Parse error before "while"
-file, line 1: Parse error before end of line
+file:1: error: Parse error before "while"
+file:1: error: Parse error before end of line
 
 [case testInvalidEllipsis1]
 ...0
 ..._
 ...a
 [out]
-file, line 1: Parse error before numeric literal
-file, line 2: Parse error before "_"
-file, line 3: Parse error before "a"
+file:1: error: Parse error before numeric literal
+file:2: error: Parse error before "_"
+file:3: error: Parse error before "a"
 
 [case testBlockStatementInSingleLineIf]
 if 1: if 2: pass
 [out]
-file, line 1: Parse error before "if"
+file:1: error: Parse error before "if"
 
 [case testBlockStatementInSingleLineIf2]
 if 1: while 2: pass
 [out]
-file, line 1: Parse error before "while"
+file:1: error: Parse error before "while"
 
 [case testBlockStatementInSingleLineIf3]
 if 1: for x in y: pass
 [out]
-file, line 1: Parse error before "for"
+file:1: error: Parse error before "for"
 
 [case testUnexpectedEllipsis]
 a = a...
 [out]
-file, line 1: Parse error before ...
+file:1: error: Parse error before ...
 
 [case testFromFutureImportStar]
 from __future__ import *
 x = 1
 [out]
-file, line 1: Parse error before *
+file:1: error: Parse error before *
 
 [case testParseErrorBeforeUnicodeLiteral]
 x u'y'
 [out]
-file, line 1: Parse error before string literal
+file:1: error: Parse error before string literal
 
 [case testParseErrorInExtendedSlicing]
 x[:,
 [out]
-file, line 1: Parse error before end of line
+file:1: error: Parse error before end of line
 
 [case testParseErrorInExtendedSlicing2]
 x[:,::
 [out]
-file, line 1: Parse error before end of line
+file:1: error: Parse error before end of line
 
 [case testParseErrorInExtendedSlicing3]
 x[:,:
 [out]
-file, line 1: Parse error before end of line
+file:1: error: Parse error before end of line
 
 [case testPython2OctalIntLiteralInPython3]
 0377
 [out]
-file, line 1: Invalid numeric literal
+file:1: error: Invalid numeric literal
 
 [case testInvalidEncoding]
 # foo
 # coding: uft-8
 [out]
-file, line 2: Unknown encoding 'uft-8'
+file:2: error: Unknown encoding 'uft-8'
 
 [case testInvalidEncoding2]
 # coding=Uft.8
 [out]
-file, line 1: Unknown encoding 'Uft.8'
+file:1: error: Unknown encoding 'Uft.8'
 
 [case testInvalidEncoding2]
 #!/usr/bin python
 # vim: set fileencoding=uft8 :
 [out]
-file, line 2: Unknown encoding 'uft8'
+file:2: error: Unknown encoding 'uft8'

--- a/mypy/test/data/parse.test
+++ b/mypy/test/data/parse.test
@@ -991,13 +991,13 @@ MypyFile:1(
 x not y
 x not is y
 [out]
-<input>, line 1: Parse error before "y"
-<input>, line 2: Parse error before is
+<input>:1: error: Parse error before "y"
+<input>:2: error: Parse error before is
 
 [case testBinaryNegAsBinaryOp]
 1 ~ 2
 [out]
-<input>, line 1: Parse error before ~
+<input>:1: error: Parse error before ~
 
 [case testDictionaryExpression]
 {}

--- a/mypy/test/data/python2eval.test
+++ b/mypy/test/data/python2eval.test
@@ -14,8 +14,8 @@ abs(1) + 'x'  # Error
 f = abs(1.1)
 abs(1.1) + 'x'  # Error
 [out]
-_program.py, line 5: Unsupported operand types for + ("int" and "str")
-_program.py, line 7: Unsupported operand types for + ("float" and "str")
+_program.py:5: error: Unsupported operand types for + ("int" and "str")
+_program.py:7: error: Unsupported operand types for + ("float" and "str")
 
 [case testUnicode_python2]
 import typing
@@ -134,8 +134,8 @@ f(b'')
 f(u'')
 f('')
 [out]
-_program.py, line 4: Argument 1 to "f" has incompatible type "unicode"; expected "str"
-_program.py, line 5: Argument 1 to "f" has incompatible type "unicode"; expected "str"
+_program.py:4: error: Argument 1 to "f" has incompatible type "unicode"; expected "str"
+_program.py:5: error: Argument 1 to "f" has incompatible type "unicode"; expected "str"
 
 [case testStrUnicodeCompatibility_python2]
 import typing
@@ -184,7 +184,7 @@ f.write(u'foo')
 f.write('bar')
 f.close()
 [out]
-_program.py, line 3: No overload variant of "write" of "BinaryIO" matches argument types
+_program.py:3: error: No overload variant of "write" of "BinaryIO" matches argument types
 
 [case testPrintFunctionWithFileArg_python2]
 from __future__ import print_function
@@ -256,8 +256,8 @@ n = 0
 n = s + '' # E
 s = s + u'' # E
 [out]
-_program.py, line 5: Incompatible types in assignment (expression has type "str", variable has type "int")
-_program.py, line 6: Incompatible types in assignment (expression has type "unicode", variable has type "str")
+_program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+_program.py:6: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
 
 [case testStrJoin_python2]
 import typing
@@ -267,8 +267,8 @@ n = 0
 n = ''.join([''])   # Error
 s = ''.join([u''])  # Error
 [out]
-_program.py, line 5: Incompatible types in assignment (expression has type "str", variable has type "int")
-_program.py, line 6: Incompatible types in assignment (expression has type "unicode", variable has type "str")
+_program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+_program.py:6: error: Incompatible types in assignment (expression has type "unicode", variable has type "str")
 
 [case testNamedTuple_python2]
 import typing
@@ -286,7 +286,7 @@ X = namedtuple('X', ['a', 'b'])
 x = X(a=1, b='s')
 x.c
 [out]
-_program.py, line 5: "X" has no attribute "c"
+_program.py:5: error: "X" has no attribute "c"
 
 [case testAssignToComplexReal_python2]
 import typing
@@ -295,8 +295,8 @@ y = x.real
 y = x         # Error
 x.imag = 2.0  # Error
 [out]
-_program.py, line 4: Incompatible types in assignment (expression has type "complex", variable has type "float")
-_program.py, line 5: Property "imag" defined in "complex" is read-only
+_program.py:4: error: Incompatible types in assignment (expression has type "complex", variable has type "float")
+_program.py:5: error: Property "imag" defined in "complex" is read-only
 
 [case testComplexArithmetic_python2]
 import typing
@@ -327,7 +327,7 @@ U = Union[int, str]
 u = 1 # type: U
 u = 1.1
 [out]
-_program.py, line 4: Incompatible types in assignment (expression has type "float", variable has type "Union[int, str]")
+_program.py:4: error: Incompatible types in assignment (expression has type "float", variable has type "Union[int, str]")
 
 [case testSuperNew_python2]
 from typing import Dict, Any

--- a/mypy/test/data/pythoneval-asyncio.test
+++ b/mypy/test/data/pythoneval-asyncio.test
@@ -270,8 +270,8 @@ try:
 finally:
     loop.close()
 [out]
-_program.py: In function "test":
-_program.py, line 13: Function does not return a value
+_program.py: note: In function "test":
+_program.py:13: error: Function does not return a value
 
 [case testErrorReturnIsNotTheSameType]
 import asyncio
@@ -293,8 +293,8 @@ loop.run_until_complete(print_sum(1, 2))
 loop.close()
 
 [out]
-_program.py: In function "compute":
-_program.py, line 8: Incompatible return value type: expected asyncio.futures.Future[builtins.int], got asyncio.futures.Future[builtins.str]
+_program.py: note: In function "compute":
+_program.py:8: error: Incompatible return value type: expected asyncio.futures.Future[builtins.int], got asyncio.futures.Future[builtins.str]
 
 [case testErrorSetFutureDifferentInternalType]
 import asyncio
@@ -312,8 +312,8 @@ loop.run_until_complete(future)
 print(future.result())
 loop.close()
 [out]
-_program.py: In function "slow_operation":
-_program.py, line 7: Argument 1 to "set_result" of "Future" has incompatible type "int"; expected "str"
+_program.py: note: In function "slow_operation":
+_program.py:7: error: Argument 1 to "set_result" of "Future" has incompatible type "int"; expected "str"
 
 
 [case testErrorUsingDifferentFutureType]
@@ -332,7 +332,7 @@ loop.run_until_complete(future)
 print(future.result())
 loop.close()
 [out]
-_program.py, line 11: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
+_program.py:11: error: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
 
 [case testErrorUsingDifferentFutureTypeAndSetFutureDifferentInternalType]
 import asyncio
@@ -350,10 +350,10 @@ loop.run_until_complete(future)
 print(future.result())
 loop.close()
 [out]
-_program.py: In function "slow_operation":
-_program.py, line 7: Argument 1 to "set_result" of "Future" has incompatible type "str"; expected "int"
-_program.py: At top level:
-_program.py, line 11: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
+_program.py: note: In function "slow_operation":
+_program.py:7: error: Argument 1 to "set_result" of "Future" has incompatible type "str"; expected "int"
+_program.py: note: At top level:
+_program.py:11: error: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
 
 [case testErrorSettingCallbackWithDifferentFutureType]
 import typing
@@ -379,7 +379,7 @@ try:
 finally:
     loop.close()
 [out]
-_program.py, line 17: Argument 1 to "add_done_callback" of "Future" has incompatible type Callable[[Future[int]], None]; expected Callable[[Future[str]], Any]
+_program.py:17: error: Argument 1 to "add_done_callback" of "Future" has incompatible type Callable[[Future[int]], None]; expected Callable[[Future[str]], Any]
 
 [case testErrorOneMoreFutureInReturnType]
 import typing
@@ -414,8 +414,8 @@ loop = asyncio.get_event_loop()
 loop.run_until_complete(h())
 loop.close()
 [out]
-_program.py: In function "h3":
-_program.py, line 17: Incompatible return value type: expected asyncio.futures.Future[asyncio.futures.Future[asyncio.futures.Future[asyncio.futures.Future[builtins.int]]]], got asyncio.futures.Future[asyncio.futures.Future[builtins.int]]
+_program.py: note: In function "h3":
+_program.py:17: error: Incompatible return value type: expected asyncio.futures.Future[asyncio.futures.Future[asyncio.futures.Future[asyncio.futures.Future[builtins.int]]]], got asyncio.futures.Future[asyncio.futures.Future[builtins.int]]
 
 [case testErrorOneLessFutureInReturnType]
 import typing
@@ -448,8 +448,8 @@ loop = asyncio.get_event_loop()
 loop.run_until_complete(h())
 loop.close()
 [out]
-_program.py: In function "h3":
-_program.py, line 17: Incompatible return value type: expected asyncio.futures.Future[asyncio.futures.Future[builtins.int]], got asyncio.futures.Future[asyncio.futures.Future[builtins.int]]
+_program.py: note: In function "h3":
+_program.py:17: error: Incompatible return value type: expected asyncio.futures.Future[asyncio.futures.Future[builtins.int]], got asyncio.futures.Future[asyncio.futures.Future[builtins.int]]
 
 [case testErrorAssignmentDifferentType]
 import typing
@@ -475,5 +475,5 @@ future.set_result(A(42))
 loop.run_until_complete(h())
 loop.close()
 [out]
-_program.py: In function "h":
-_program.py, line 15: Incompatible types in assignment (expression has type "A", variable has type "B")
+_program.py: note: In function "h":
+_program.py:15: error: Incompatible types in assignment (expression has type "A", variable has type "B")

--- a/mypy/test/data/pythoneval.test
+++ b/mypy/test/data/pythoneval.test
@@ -107,8 +107,8 @@ abs(1) + 'x'  # Error
 f = abs(1.1)
 abs(1.1) + 'x'  # Error
 [out]
-_program.py, line 5: Unsupported operand types for + ("int" and "str")
-_program.py, line 7: Unsupported operand types for + ("float" and "str")
+_program.py:5: error: Unsupported operand types for + ("int" and "str")
+_program.py:7: error: Unsupported operand types for + ("float" and "str")
 
 [case testRound]
 from typing import SupportsRound
@@ -367,7 +367,7 @@ b'zar'
 import typing
 cast(int, 2)
 [out]
-_program.py, line 2: Name 'cast' is not defined
+_program.py:2: error: Name 'cast' is not defined
 
 [case testBinaryIOType]
 from typing import BinaryIO
@@ -388,10 +388,10 @@ def bin(f: IO[bytes]) -> None:
 txt(sys.stdout)
 bin(sys.stdout)
 [out]
-_program.py: In function "txt":
-_program.py, line 5: Argument 1 to "write" of "IO" has incompatible type "bytes"; expected "str"
-_program.py: At top level:
-_program.py, line 10: Argument 1 to "bin" has incompatible type "TextIO"; expected IO[bytes]
+_program.py: note: In function "txt":
+_program.py:5: error: Argument 1 to "write" of "IO" has incompatible type "bytes"; expected "str"
+_program.py: note: At top level:
+_program.py:10: error: Argument 1 to "bin" has incompatible type "TextIO"; expected IO[bytes]
 
 [case testBuiltinOpen]
 f = open('x')
@@ -399,7 +399,7 @@ f.write('x')
 f.write(b'x')
 f.foobar()
 [out]
-_program.py, line 4: IO[Any] has no attribute "foobar"
+_program.py:4: error: IO[Any] has no attribute "foobar"
 
 [case testGenericPatterns]
 from typing import Pattern
@@ -430,9 +430,9 @@ S = TypeVar('S', int, str)
 def f(t: T, s: S) -> None:
     t + s
 [out]
-_program.py: In function "f":
-_program.py, line 7: Unsupported operand types for + ("int" and "str")
-_program.py, line 7: Unsupported operand types for + ("str" and "int")
+_program.py: note: In function "f":
+_program.py:7: error: Unsupported operand types for + ("int" and "str")
+_program.py:7: error: Unsupported operand types for + ("str" and "int")
 
 [case testSystemExitCode]
 import typing
@@ -472,7 +472,7 @@ n = abs(2)
 f = abs(2.2)
 abs(2.2) + 'x'
 [out]
-_program.py, line 6: Unsupported operand types for + ("float" and "str")
+_program.py:6: error: Unsupported operand types for + ("float" and "str")
 
 [case testROperatorMethods]
 
@@ -484,7 +484,7 @@ b = b'foo' * 5
 s = 5 * 'foo'
 s = 'foo' * 5
 [out]
-_program.py, line 4: Incompatible types in assignment (expression has type "bytes", variable has type "str")
+_program.py:4: error: Incompatible types in assignment (expression has type "bytes", variable has type "str")
 
 [case testROperatorMethods2]
 import typing
@@ -535,8 +535,8 @@ b = None  # type: B
 b = C()
 print(A() + b)
 [out]
-_program.py: In member "__radd__" of class "B":
-_program.py, line 9: Signatures of "__radd__" of "B" and "__add__" of "A" are unsafely overlapping
+_program.py: note: In member "__radd__" of class "B":
+_program.py:9: error: Signatures of "__radd__" of "B" and "__add__" of "A" are unsafely overlapping
 
 [case testBytesAndBytearrayComparisons]
 import typing
@@ -553,10 +553,10 @@ b'' < ''
 '' < bytearray()
 bytearray() < ''
 [out]
-_program.py, line 2: Unsupported operand types for > ("bytes" and "str")
-_program.py, line 3: Unsupported operand types for > ("str" and "bytes")
-_program.py, line 4: Unsupported operand types for > ("bytearray" and "str")
-_program.py, line 5: Unsupported operand types for > ("str" and "bytearray")
+_program.py:2: error: Unsupported operand types for > ("bytes" and "str")
+_program.py:3: error: Unsupported operand types for > ("str" and "bytes")
+_program.py:4: error: Unsupported operand types for > ("bytearray" and "str")
+_program.py:5: error: Unsupported operand types for > ("str" and "bytearray")
 
 [case testInplaceOperatorMethod]
 import typing
@@ -579,7 +579,7 @@ print(tuple(a))
 import typing
 [1] + iter([2, 3])
 [out]
-_program.py, line 2: Unsupported operand types for + ("list" and Iterator[int])
+_program.py:2: error: Unsupported operand types for + ("list" and Iterator[int])
 
 [case testInferHeterogeneousListOfIterables]
 from typing import Sequence
@@ -749,8 +749,8 @@ print('>', list(b))
 import typing
 def f(x: _T) -> None: pass
 [out]
-_program.py: In function "f":
-_program.py, line 2: Name '_T' is not defined
+_program.py: note: In function "f":
+_program.py:2: error: Name '_T' is not defined
 
 [case testVarArgsFunctionSubtyping]
 import typing
@@ -758,7 +758,7 @@ def f(*args: str) -> str: return args[0]
 map(f, ['x'])
 map(f, [1])
 [out]
-_program.py, line 4: Argument 1 to "map" has incompatible type Callable[[str], str]; expected Callable[[int], str]
+_program.py:4: error: Argument 1 to "map" has incompatible type Callable[[str], str]; expected Callable[[int], str]
 
 [case testMapStr]
 import typing
@@ -766,7 +766,7 @@ x = range(3)
 a = list(map(str, x))
 a + 1
 [out]
-_program.py, line 4: Unsupported operand types for + (List[str] and "int")
+_program.py:4: error: Unsupported operand types for + (List[str] and "int")
 
 [case testNamedTuple]
 import typing
@@ -793,7 +793,7 @@ X = namedtuple('X', ['a', 'b'])
 x = X(a=1, b='s')
 x.c
 [out]
-_program.py, line 5: "X" has no attribute "c"
+_program.py:5: error: "X" has no attribute "c"
 
 [case testNamedTupleTupleOperations]
 from typing import Iterable
@@ -858,7 +858,7 @@ def f(x):
 import typing
 def f(x: str) -> None: pass
 [out]
-_program.py, line 2: Argument 1 to "f" has incompatible type "int"; expected "str"
+_program.py:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
 [case testAssignToComplexReal]
 import typing
@@ -867,8 +867,8 @@ y = x.real
 y = x         # Error
 x.real = 2.0  # Error
 [out]
-_program.py, line 4: Incompatible types in assignment (expression has type "complex", variable has type "float")
-_program.py, line 5: Property "real" defined in "complex" is read-only
+_program.py:4: error: Incompatible types in assignment (expression has type "complex", variable has type "float")
+_program.py:5: error: Property "real" defined in "complex" is read-only
 
 [case testComplexArithmetic]
 import typing
@@ -887,8 +887,8 @@ x = ''
 y = 3j * 2.0
 y = ''
 [out]
-_program.py, line 3: Incompatible types in assignment (expression has type "str", variable has type "complex")
-_program.py, line 5: Incompatible types in assignment (expression has type "str", variable has type "complex")
+_program.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "complex")
+_program.py:5: error: Incompatible types in assignment (expression has type "str", variable has type "complex")
 
 [case testUnionTypeAlias]
 from typing import Union
@@ -896,7 +896,7 @@ U = Union[int, str]
 u = 1 # type: U
 u = 1.1
 [out]
-_program.py, line 4: Incompatible types in assignment (expression has type "float", variable has type "Union[int, str]")
+_program.py:4: error: Incompatible types in assignment (expression has type "float", variable has type "Union[int, str]")
 
 [case testTupleTypeAlias]
 from typing import Tuple
@@ -904,7 +904,7 @@ A = Tuple[int, str]
 u = 1, 'x' # type: A
 u = 1
 [out]
-_program.py, line 4: Incompatible types in assignment (expression has type "int", variable has type "Tuple[int, str]")
+_program.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "Tuple[int, str]")
 
 [case testCallableTypeAlias]
 from typing import Callable
@@ -913,8 +913,8 @@ def f(x: A) -> None:
     x(1)
     x('')
 [out]
-_program.py: In function "f":
-_program.py, line 5: Argument 1 has incompatible type "str"; expected "int"
+_program.py: note: In function "f":
+_program.py:5: error: Argument 1 has incompatible type "str"; expected "int"
 
 [case testSuperNew]
 from typing import Dict, Any
@@ -970,8 +970,8 @@ def f(*x: int) -> None:
     x.append(1)
 f(1)
 [out]
-_program.py: In function "f":
-_program.py, line 3: Sequence[int] has no attribute "append"
+_program.py: note: In function "f":
+_program.py:3: error: Sequence[int] has no attribute "append"
 
 [case testExit]
 print('a')

--- a/mypy/test/data/semanal-classes.test
+++ b/mypy/test/data/semanal-classes.test
@@ -564,9 +564,9 @@ class A(None): pass
 class B(Any): pass
 class C(Callable[[], int]): pass
 [out]
-main, line 2: Invalid base class
-main, line 3: Invalid base class
-main, line 4: Invalid base class
+main:2: error: Invalid base class
+main:3: error: Invalid base class
+main:4: error: Invalid base class
 
 [case testTupleAsBaseClass]
 from typing import Tuple

--- a/mypy/test/data/semanal-errors.test
+++ b/mypy/test/data/semanal-errors.test
@@ -3,17 +3,17 @@ in 1
 def f():
   1 1
 [out]
-main, line 1: Parse error before in
-main: In function "f":
-main, line 3: Parse error before numeric literal
+main:1: error: Parse error before in
+main: note: In function "f":
+main:3: error: Parse error before numeric literal
 
 [case testUndefinedVariableInGlobalStatement]
 import typing
 x
 y
 [out]
-main, line 2: Name 'x' is not defined
-main, line 3: Name 'y' is not defined
+main:2: error: Name 'x' is not defined
+main:3: error: Name 'y' is not defined
 
 [case testUndefinedVariableWithinFunctionContext]
 import typing
@@ -21,10 +21,10 @@ def f():
   x
 y
 [out]
-main: In function "f":
-main, line 3: Name 'x' is not defined
-main: At top level:
-main, line 4: Name 'y' is not defined
+main: note: In function "f":
+main:3: error: Name 'x' is not defined
+main: note: At top level:
+main:4: error: Name 'y' is not defined
 
 [case testMethodScope]
 import typing
@@ -32,7 +32,7 @@ class A:
   def f(self): pass
 f
 [out]
-main, line 4: Name 'f' is not defined
+main:4: error: Name 'f' is not defined
 
 [case testMethodScope2]
 import typing
@@ -43,15 +43,15 @@ class B:
     f # error
     g # error
 [out]
-main: In function "g":
-main, line 6: Name 'f' is not defined
-main, line 7: Name 'g' is not defined
+main: note: In function "g":
+main:6: error: Name 'f' is not defined
+main:7: error: Name 'g' is not defined
 
 [case testInvalidType]
 import typing
 x = None # type: X
 [out]
-main, line 2: Name 'X' is not defined
+main:2: error: Name 'X' is not defined
 
 [case testInvalidGenericArg]
 from typing import TypeVar, Generic
@@ -59,7 +59,7 @@ t = TypeVar('t')
 class A(Generic[t]): pass
 x = 0 # type: A[y]
 [out]
-main, line 4: Name 'y' is not defined
+main:4: error: Name 'y' is not defined
 
 [case testInvalidNumberOfGenericArgsInTypeDecl]
 from typing import TypeVar, Generic
@@ -69,8 +69,8 @@ class B(Generic[t]): pass
 x = 0 # type: B[A, A]
 y = 0 # type: A[A]
 [out]
-main, line 5: "B" expects 1 type argument, but 2 given
-main, line 6: "A" expects no type arguments, but 1 given
+main:5: error: "B" expects 1 type argument, but 2 given
+main:6: error: "A" expects no type arguments, but 1 given
 
 [case testInvalidNumberOfGenericArgsInUndefinedArg]
 
@@ -87,14 +87,14 @@ class B:
             x = None  # type: A[int] \
                 # E: "A" expects no type arguments, but 1 given
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInvalidNumberOfGenericArgsInSignature]
 import typing
 class A: pass
 def f() -> A[int]: pass # E: "A" expects no type arguments, but 1 given
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInvalidNumberOfGenericArgsInOverloadedSignature]
 from typing import overload
@@ -104,7 +104,7 @@ def f(): pass
 @overload
 def f(x: A[int]) -> None: pass # E: "A" expects no type arguments, but 1 given
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInvalidNumberOfGenericArgsInBaseType]
 import typing
@@ -132,7 +132,7 @@ class A(Generic[T]): pass
 class B: pass
 def f() -> A[B[int]]: pass # E: "B" expects no type arguments, but 1 given
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInvalidNumberOfGenericArgsInTupleType]
 from typing import Tuple
@@ -154,8 +154,8 @@ x = 1
 y = 0 # type: f
 z = 0 # type: x
 [out]
-main, line 4: Invalid type "__main__.f"
-main, line 5: Invalid type "__main__.x"
+main:4: error: Invalid type "__main__.f"
+main:5: error: Invalid type "__main__.x"
 
 [case testTwoStarsInType]
 import typing
@@ -163,8 +163,8 @@ x = 1 # type: *object, *object
 y = 1 # type: object, (*object, *object)
 z = 1 # type: *object, (object, *object)
 [out]
-main, line 2: At most one star type allowed in a tuple
-main, line 3: At most one star type allowed in a tuple
+main:2: error: At most one star type allowed in a tuple
+main:3: error: At most one star type allowed in a tuple
 
 [case testGlobalVarRedefinition]
 import typing
@@ -172,7 +172,7 @@ class A: pass
 x = 0 # type: A
 x = 0 # type: A
 [out]
-main, line 4: Name 'x' already defined
+main:4: error: Name 'x' already defined
 
 [case testLocalVarRedefinition]
 import typing
@@ -181,8 +181,8 @@ def f():
   x = 0 # type: A
   x = 0 # type: A
 [out]
-main: In function "f":
-main, line 5: Name 'x' already defined
+main: note: In function "f":
+main:5: error: Name 'x' already defined
 
 [case testClassVarRedefinition]
 import typing
@@ -190,14 +190,14 @@ class A:
   x = 0 # type: object
   x = 0 # type: object
 [out]
-main, line 4: Name 'x' already defined
+main:4: error: Name 'x' already defined
 
 [case testMultipleClassDefinitions]
 import typing
 class A: pass
 class A: pass
 [out]
-main, line 3: Name 'A' already defined
+main:3: error: Name 'A' already defined
 
 [case testMultipleMixedDefinitions]
 import typing
@@ -205,8 +205,8 @@ x = 1
 def x(): pass
 class x: pass
 [out]
-main, line 3: Name 'x' already defined
-main, line 4: Name 'x' already defined
+main:3: error: Name 'x' already defined
+main:4: error: Name 'x' already defined
 
 [case testNameNotImported]
 import typing
@@ -215,7 +215,7 @@ x
 [file m.py]
 x = y = 1
 [out]
-main, line 3: Name 'x' is not defined
+main:3: error: Name 'x' is not defined
 
 [case testMissingNameInImportFrom]
 import typing
@@ -223,25 +223,25 @@ from m import y
 [file m.py]
 x = 1
 [out]
-main, line 2: Module has no attribute 'y'
+main:2: error: Module has no attribute 'y'
 
 [case testMissingModule]
 import typing
 import m
 [out]
-main, line 2: No module named 'm'
+main:2: error: No module named 'm'
 
 [case testMissingModule2]
 import typing
 from m import x
 [out]
-main, line 2: No module named 'm'
+main:2: error: No module named 'm'
 
 [case testMissingModule3]
 import typing
 from m import *
 [out]
-main, line 2: No module named 'm'
+main:2: error: No module named 'm'
 
 [case testMissingModuleRelativeImport]
 import typing
@@ -249,8 +249,8 @@ import m
 [file m/__init__.py]
 from .x import y
 [out]
-In module imported in main, line 2:
-tmp/m/__init__.py, line 1: No module named 'm.x'
+main:2: note: In module imported here:
+tmp/m/__init__.py:1: error: No module named 'm.x'
 
 [case testMissingModuleRelativeImport2]
 import typing
@@ -259,8 +259,8 @@ import m.a
 [file m/a.py]
 from .x import y
 [out]
-In module imported in main, line 2:
-tmp/m/a.py, line 1: No module named 'm.x'
+main:2: note: In module imported here:
+tmp/m/a.py:1: error: No module named 'm.x'
 
 [case testModuleNotImported]
 import typing
@@ -271,7 +271,7 @@ import _n
 [file _n.py]
 x = 1
 [out]
-main, line 3: Name '_n' is not defined
+main:3: error: Name '_n' is not defined
 
 [case testImportAsteriskPlusUnderscore]
 import typing
@@ -281,18 +281,18 @@ __x__
 [file _m.py]
 _x = __x__ = 1
 [out]
-main, line 3: Name '_x' is not defined
-main, line 4: Name '__x__' is not defined
+main:3: error: Name '_x' is not defined
+main:4: error: Name '__x__' is not defined
 
 [case testRelativeImportAtTopLevelModule]
 from . import m
 [out]
-main, line 1: No parent module -- cannot perform relative import
+main:1: error: No parent module -- cannot perform relative import
 
 [case testRelativeImportAtTopLevelModule]
 from .. import m
 [out]
-main, line 1: No parent module -- cannot perform relative import
+main:1: error: No parent module -- cannot perform relative import
 
 [case testUndefinedTypeWithQualifiedName]
 import typing
@@ -301,24 +301,24 @@ def f() -> m.c: pass
 def g() -> n.c: pass
 [file m.py]
 [out]
-main: In function "f":
-main, line 3: Name 'm.c' is not defined
-main: In function "g":
-main, line 4: Name 'n' is not defined
+main: note: In function "f":
+main:3: error: Name 'm.c' is not defined
+main: note: In function "g":
+main:4: error: Name 'n' is not defined
 
 [case testMissingPackage]
 import typing
 import m.n
 [out]
-main, line 2: No module named 'm.n'
+main:2: error: No module named 'm.n'
 
 [case testMissingPackage]
 import typing
 from m.n import x
 from a.b import *
 [out]
-main, line 2: No module named 'm.n'
-main, line 3: No module named 'a.b'
+main:2: error: No module named 'm.n'
+main:3: error: No module named 'a.b'
 
 [case testErrorInImportedModule]
 import m
@@ -326,8 +326,8 @@ import m
 import typing
 x = y
 [out]
-In module imported in main, line 1:
-tmp/m.py, line 2: Name 'y' is not defined
+main:1: note: In module imported here:
+tmp/m.py:2: error: Name 'y' is not defined
 
 [case testErrorInImportedModule2]
 import m.n
@@ -338,9 +338,9 @@ import k
 import typing
 x = y
 [out]
-In module imported in tmp/m/n.py, line 1,
-                   in main, line 1:
-tmp/k.py, line 2: Name 'y' is not defined
+tmp/m/n.py:1: note: In module imported here,
+main:1: note: ... from here:
+tmp/k.py:2: error: Name 'y' is not defined
 
 [case testPackageWithoutInitFile]
 import typing
@@ -349,40 +349,40 @@ m.n.x
 [file m/n.py]
 x = 1
 [out]
-main, line 2: No module named 'm.n'
+main:2: error: No module named 'm.n'
 
 [case testBreakOutsideLoop]
 break
 def f():
   break
 [out]
-main, line 1: 'break' outside loop
-main: In function "f":
-main, line 3: 'break' outside loop
+main:1: error: 'break' outside loop
+main: note: In function "f":
+main:3: error: 'break' outside loop
 
 [case testContinueOutsideLoop]
 continue
 def f():
   continue
 [out]
-main, line 1: 'continue' outside loop
-main: In function "f":
-main, line 3: 'continue' outside loop
+main:1: error: 'continue' outside loop
+main: note: In function "f":
+main:3: error: 'continue' outside loop
 
 [case testReturnOutsideFunction]
 def f(): pass
 return
 return 1
 [out]
-main, line 2: 'return' outside function
-main, line 3: 'return' outside function
+main:2: error: 'return' outside function
+main:3: error: 'return' outside function
 
 [case testYieldOutsideFunction]
 yield 1
 yield
 [out]
-main, line 1: 'yield' outside function
-main, line 2: 'yield' outside function
+main:1: error: 'yield' outside function
+main:2: error: 'yield' outside function
 
 [case testInvalidLvalues]
 1 = 1
@@ -391,11 +391,11 @@ main, line 2: 'yield' outside function
 [1, 1] = 1
 () = 1
 [out]
-main, line 1: Invalid assignment target
-main, line 2: Invalid assignment target
-main, line 3: Invalid assignment target
-main, line 4: Invalid assignment target
-main, line 5: Can't assign to ()
+main:1: error: Invalid assignment target
+main:2: error: Invalid assignment target
+main:3: error: Invalid assignment target
+main:4: error: Invalid assignment target
+main:5: error: Can't assign to ()
 --' (hack to fix syntax highlighting)
 
 [case testInvalidLvalues2]
@@ -407,10 +407,10 @@ x, (y, (z, 1)) = 1
 x, (y) = 1 # ok
 x, (y, (z, z)) = 1 # ok
 [out]
-main, line 2: Invalid assignment target
-main, line 3: Invalid assignment target
-main, line 4: Invalid assignment target
-main, line 5: Invalid assignment target
+main:2: error: Invalid assignment target
+main:3: error: Invalid assignment target
+main:4: error: Invalid assignment target
+main:5: error: Invalid assignment target
 
 [case testInvalidLvalues3]
 x = 1
@@ -420,21 +420,21 @@ x + x = 1
 'x' = 1
 x() = 1
 [out]
-main, line 2: Invalid assignment target
-main, line 3: Invalid assignment target
-main, line 4: Invalid assignment target
-main, line 5: Invalid assignment target
-main, line 6: Invalid assignment target
+main:2: error: Invalid assignment target
+main:3: error: Invalid assignment target
+main:4: error: Invalid assignment target
+main:5: error: Invalid assignment target
+main:6: error: Invalid assignment target
 
 [case testInvalidStarType]
 a = 1  # type: *int
 [out]
-main, line 1: Star type only allowed for starred expressions
+main:1: error: Star type only allowed for starred expressions
 
 [case testInvalidStarType]
 *a, b = 1  # type: int, int
 [out]
-main, line 1: Star type expected for starred expression
+main:1: error: Star type expected for starred expression
 
 [case testTwoStarExpressions]
 a, *b, *c = 1
@@ -442,9 +442,9 @@ a, *b, *c = 1
 a, (*b, *c) = 1
 [*a, *b] = 1
 [out]
-main, line 1: Two starred expressions in assignment
-main, line 3: Two starred expressions in assignment
-main, line 4: Two starred expressions in assignment
+main:1: error: Two starred expressions in assignment
+main:3: error: Two starred expressions in assignment
+main:4: error: Two starred expressions in assignment
 
 [case testTwoStarExpressionsInForStmt]
 for a, *b, *c in z:
@@ -456,18 +456,18 @@ for a, (*b, *c) in z:
 for [*a, *b] in z:
     pass
 [out]
-main, line 1: Two starred expressions in assignment
-main, line 5: Two starred expressions in assignment
-main, line 7: Two starred expressions in assignment
+main:1: error: Two starred expressions in assignment
+main:5: error: Two starred expressions in assignment
+main:7: error: Two starred expressions in assignment
 
 [case testTwoStarExpressionsInGeneratorExpr]
 (a for a, *b, *c in [])
 (a for *a, (*b, c) in [])
 (a for a, (*b, *c) in [])
 [out]
-main, line 1: Two starred expressions in assignment
-main, line 1: Name 'a' is not defined
-main, line 3: Two starred expressions in assignment
+main:1: error: Two starred expressions in assignment
+main:1: error: Name 'a' is not defined
+main:3: error: Two starred expressions in assignment
 
 [case testStarExpressionRhs]
 b = 1
@@ -476,14 +476,14 @@ d = 1
 a = *b
 a = b, (c, *d)
 [out]
-main, line 4: Can use starred expression only as assignment target
-main, line 5: Can use starred expression only as assignment target
+main:4: error: Can use starred expression only as assignment target
+main:5: error: Can use starred expression only as assignment target
 
 [case testStarExpressionInExp]
 a = 1
 *a + 1
 [out]
-main, line 2: Can use starred expression only as assignment target
+main:2: error: Can use starred expression only as assignment target
 
 [case testInvalidDel]
 import typing
@@ -499,7 +499,7 @@ t = TypeVar('t')
 def f(x: t) -> t: pass
 x = 0 # type: t
 [out]
-main, line 4: Invalid type "__main__.t"
+main:4: error: Invalid type "__main__.t"
 
 [case testClassTvarScope]
 from typing import Generic, TypeVar
@@ -507,7 +507,7 @@ t = TypeVar('t')
 class c(Generic[t]): pass
 x = 0 # type: t
 [out]
-main, line 4: Invalid type "__main__.t"
+main:4: error: Invalid type "__main__.t"
 
 [case testExpressionRefersToTypeVariable]
 from typing import TypeVar, Generic
@@ -516,31 +516,31 @@ class c(Generic[t]):
     def f(self): x = t
 def f(y: t): x = t
 [out]
-main: In function "f":
-main, line 4: 't' is a type variable and only valid in type context
-main, line 5: 't' is a type variable and only valid in type context
+main: note: In function "f":
+main:4: error: 't' is a type variable and only valid in type context
+main:5: error: 't' is a type variable and only valid in type context
 
 [case testMissingSelf]
 import typing
 class A:
   def f(): pass
 [out]
-main, line 3: Method must have at least one argument
+main:3: error: Method must have at least one argument
 
 [case testInvalidBaseClass]
 import typing
 class A(B): pass
 [out]
-main, line 2: Name 'B' is not defined
+main:2: error: Name 'B' is not defined
 
 [case testSuperOutsideClass]
 class A: pass
 super().x
 def f(): super().y
 [out]
-main, line 2: "super" used outside class
-main: In function "f":
-main, line 3: "super" used outside class
+main:2: error: "super" used outside class
+main: note: In function "f":
+main:3: error: "super" used outside class
 
 [case testMissingSelfInMethod]
 import typing
@@ -548,8 +548,8 @@ class A:
   def f() -> None: pass
   def g(): pass
 [out]
-main, line 3: Method must have at least one argument
-main, line 4: Method must have at least one argument
+main:3: error: Method must have at least one argument
+main:4: error: Method must have at least one argument
 
 [case testMultipleMethodDefinition]
 import typing
@@ -558,7 +558,7 @@ class A:
   def g(self) -> None: pass
   def f(self, x: object) -> None: pass
 [out]
-main, line 5: Name 'f' already defined
+main:5: error: Name 'f' already defined
 
 [case testInvalidGlobalDecl]
 import typing
@@ -566,8 +566,8 @@ def f():
     global x
     x = None
 [out]
-main: In function "f":
-main, line 4: Name 'x' is not defined
+main: note: In function "f":
+main:4: error: Name 'x' is not defined
 
 [case testInvalidNonlocalDecl]
 import typing
@@ -576,9 +576,9 @@ def f():
        nonlocal x
        x = None
 [out]
-main: In function "g":
-main, line 4: No binding for nonlocal 'x' found
-main, line 5: Name 'x' is not defined
+main: note: In function "g":
+main:4: error: No binding for nonlocal 'x' found
+main:5: error: Name 'x' is not defined
 
 [case testNonlocalDeclNotMatchingGlobal]
 import typing
@@ -587,9 +587,9 @@ def f():
     nonlocal x
     x = None
 [out]
-main: In function "f":
-main, line 4: No binding for nonlocal 'x' found
-main, line 5: Name 'x' is not defined
+main: note: In function "f":
+main:4: error: No binding for nonlocal 'x' found
+main:5: error: Name 'x' is not defined
 
 [case testNonlocalDeclConflictingWithParameter]
 import typing
@@ -599,14 +599,14 @@ def g():
         nonlocal x
         x = None
 [out]
-main: In function "f":
-main, line 5: Name 'x' is already defined in local scope before nonlocal declaration
+main: note: In function "f":
+main:5: error: Name 'x' is already defined in local scope before nonlocal declaration
 
 [case testNonlocalDeclOutsideFunction]
 x = 2
 nonlocal x
 [out]
-main, line 2: nonlocal declaration not allowed at module level
+main:2: error: nonlocal declaration not allowed at module level
 
 [case testGlobalAndNonlocalDecl]
 import typing
@@ -618,8 +618,8 @@ def f():
        nonlocal x
        x = None
 [out]
-main: In function "g":
-main, line 7: Name 'x' is nonlocal and global
+main: note: In function "g":
+main:7: error: Name 'x' is nonlocal and global
 
 [case testNonlocalAndGlobalDecl]
 import typing
@@ -631,8 +631,8 @@ def f():
        global x
        x = None
 [out]
-main: In function "g":
-main, line 7: Name 'x' is nonlocal and global
+main: note: In function "g":
+main:7: error: Name 'x' is nonlocal and global
 
 [case testNestedFunctionAndScoping]
 import typing
@@ -643,9 +643,9 @@ def f(x):
     y
     x
 [out]
-main: In function "f":
-main, line 5: Name 'z' is not defined
-main, line 6: Name 'y' is not defined
+main: note: In function "f":
+main:5: error: Name 'z' is not defined
+main:6: error: Name 'y' is not defined
 
 [case testMultipleNestedFunctionDef]
 import typing
@@ -654,8 +654,8 @@ def f(x):
     x = 1
     def g(): pass
 [out]
-main: In function "f":
-main, line 5: Name 'g' already defined
+main: note: In function "f":
+main:5: error: Name 'g' already defined
 
 [case testRedefinedOverloadedFunction]
 from typing import overload, Any
@@ -667,8 +667,8 @@ def f():
     x = 1
     def p(): pass # fail
 [out]
-main: In function "f":
-main, line 8: Name 'p' already defined
+main: note: In function "f":
+main:8: error: Name 'p' already defined
 
 [case testNestedFunctionInMethod]
 import typing
@@ -678,10 +678,10 @@ class A:
            x
        y
 [out]
-main: In function "g":
-main, line 5: Name 'x' is not defined
-main: In function "f":
-main, line 6: Name 'y' is not defined
+main: note: In function "g":
+main:5: error: Name 'x' is not defined
+main: note: In function "f":
+main:6: error: Name 'y' is not defined
 
 [case testImportScope]
 import typing
@@ -733,9 +733,9 @@ import x # ok, since we may import multiple submodules of a package
 [file x.py]
 a = 1
 [out]
-main, line 2: Name 'a' already defined
-main: In function "f":
-main, line 5: Name 'a' already defined
+main:2: error: Name 'a' already defined
+main: note: In function "f":
+main:5: error: Name 'a' already defined
 
 [case testScopeOfNestedClass]
 import typing
@@ -834,7 +834,7 @@ def g() -> None:
 [file m.py]
 def f(): pass
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testAssignToTypeDef]
 import typing
@@ -894,7 +894,7 @@ Any(arg=str)   # E: 'Any' must be called with 1 positional argument
 def f(x:[int, str]) -> None: # E: Invalid type
     pass
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInvalidFunctionType]
 from typing import Callable
@@ -902,9 +902,9 @@ x = None # type: Callable[int, str]
 y = None # type: Callable[int]
 z = None # type: Callable[int, int, int]
 [out]
-main, line 2: Invalid function type
-main, line 3: Invalid function type
-main, line 4: Invalid function type
+main:2: error: Invalid function type
+main:3: error: Invalid function type
+main:4: error: Invalid function type
 
 [case testAbstractGlobalFunction]
 import typing
@@ -912,7 +912,7 @@ from abc import abstractmethod
 @abstractmethod
 def foo(): pass
 [out]
-main, line 3: 'abstractmethod' used with a non-method
+main:3: error: 'abstractmethod' used with a non-method
 
 [case testAbstractNestedFunction]
 import typing
@@ -921,27 +921,27 @@ def g():
   @abstractmethod
   def foo(): pass
 [out]
-main: In function "g":
-main, line 4: 'abstractmethod' used with a non-method
+main: note: In function "g":
+main:4: error: 'abstractmethod' used with a non-method
 
 [case testInvalidTypeDeclaration]
 import typing
 def f(): pass
 f() = 1 # type: int
 [out]
-main, line 3: Invalid assignment target
+main:3: error: Invalid assignment target
 
 [case testIndexedAssignmentWithTypeDeclaration]
 import typing
 None[1] = 1 # type: int
 [out]
-main, line 2: Unexpected type declaration
+main:2: error: Unexpected type declaration
 
 [case testNonSelfMemberAssignmentWithTypeDeclaration]
 import typing
 None.x = 1 # type: int
 [out]
-main, line 2: Type cannot be declared in assignment to non-self attribute
+main:2: error: Type cannot be declared in assignment to non-self attribute
 
 [case testNonSelfMemberAssignmentWithTypeDeclarationInMethod]
 import typing
@@ -949,8 +949,8 @@ class A:
   def f(self, x) -> None:
     x.y = 1 # type: int
 [out]
-main: In function "f":
-main, line 4: Type cannot be declared in assignment to non-self attribute
+main: note: In function "f":
+main:4: error: Type cannot be declared in assignment to non-self attribute
 
 [case testInvalidTypeInTypeApplication]
 from typing import TypeVar, Generic
@@ -1015,7 +1015,7 @@ from typing import TypeVar
 T = TypeVar('T')
 class A(Generic[T]): pass
 [out]
-main, line 3: Name 'Generic' is not defined
+main:3: error: Name 'Generic' is not defined
 
 [case testInvalidTypeWithinGeneric]
 from typing import Generic
@@ -1073,8 +1073,8 @@ c = TypeVar('c', int, 2) # E: Type expected
 from typing import TypeVar
 a = TypeVar('a', values=(int, str))
 [out]
-main, line 2: TypeVar 'values' argument not supported
-main, line 2: Use TypeVar('T', t, ...) instead of TypeVar('T', values=(t, ...))
+main:2: error: TypeVar 'values' argument not supported
+main:2: error: Use TypeVar('T', t, ...) instead of TypeVar('T', values=(t, ...))
 
 [case testLocalTypevarScope]
 from typing import TypeVar
@@ -1082,7 +1082,7 @@ def f() -> None:
     T = TypeVar('T')
 def g(x: T) -> None: pass # E: Name 'T' is not defined
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testClassTypevarScope]
 from typing import TypeVar
@@ -1090,7 +1090,7 @@ class A:
     T = TypeVar('T')
 def g(x: T) -> None: pass # E: Name 'T' is not defined
 [out]
-main: In function "g":
+main: note: In function "g":
 
 [case testRedefineVariableAsTypevar]
 from typing import TypeVar
@@ -1130,12 +1130,12 @@ from typing import Generic as t # E: Name 't' already defined
 [case testInvalidStrLiteralType]
 def f(x: 'foo'): pass # E: Name 'foo' is not defined
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInvalidStrLiteralType2]
 def f(x: 'int['): pass # E: Parse error before end of line
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testInconsistentOverload]
 from typing import overload
@@ -1171,10 +1171,10 @@ def f(): # type: (int) -> int
 def g(x): # type: () -> int
   pass
 [out]
-main: In function "f":
-main, line 2: Type signature has too many arguments
-main: In function "g":
-main, line 4: Type signature has too few arguments
+main: note: In function "f":
+main:2: error: Type signature has too many arguments
+main: note: In function "g":
+main:4: error: Type signature has too few arguments
 
 [case testStaticmethodAndNonMethod]
 import typing
@@ -1186,9 +1186,9 @@ class A:
     def h(): pass
 [builtins fixtures/staticmethod.py]
 [out]
-main, line 2: 'staticmethod' used with a non-method
-main: In function "g":
-main, line 6: 'staticmethod' used with a non-method
+main:2: error: 'staticmethod' used with a non-method
+main: note: In function "g":
+main:6: error: 'staticmethod' used with a non-method
 
 [case testClassmethodAndNonMethod]
 import typing
@@ -1200,9 +1200,9 @@ class A:
     def h(): pass
 [builtins fixtures/classmethod.py]
 [out]
-main, line 2: 'classmethod' used with a non-method
-main: In function "g":
-main, line 6: 'classmethod' used with a non-method
+main:2: error: 'classmethod' used with a non-method
+main: note: In function "g":
+main:6: error: 'classmethod' used with a non-method
 
 [case testNonMethodProperty]
 import typing
@@ -1267,7 +1267,7 @@ def f() -> None:
 y = 1
 [file y.py]
 [out]
-main: In function "f":
+main: note: In function "f":
 
 [case testImportTwoModulesWithSameNameInGlobalContext]
 import typing
@@ -1284,8 +1284,8 @@ import typing
 def f() -> List[int]: pass
 [builtins fixtures/list.py]
 [out]
-main: In function "f":
-main, line 2: Name 'List' is not defined
+main: note: In function "f":
+main:2: error: Name 'List' is not defined
 
 [case testImportObsoleteTypingFunction]
 from typing import Function # E: Module has no attribute 'Function' (it's now called 'typing.Callable')
@@ -1300,17 +1300,17 @@ def f(x: typing.Function[[], None]) -> None: pass
 def g(x: _m.Function[[], None]) -> None: pass
 [file _m.py]
 [out]
-main: In function "f":
-main, line 3: Name 'typing.Function' is not defined (it's now called 'typing.Callable')
+main: note: In function "f":
+main:3: error: Name 'typing.Function' is not defined (it's now called 'typing.Callable')
 --'
-main: In function "g":
-main, line 4: Name '_m.Function' is not defined
+main: note: In function "g":
+main:4: error: Name '_m.Function' is not defined
 
 [case testUnqualifiedNameRefersToObsoleteTypingFunction]
 x = None # type: Function[[], None]
 [out]
-main, line 1: Name 'Function' is not defined
-main, line 1: (Did you mean 'typing.Callable'?)
+main:1: error: Name 'Function' is not defined
+main:1: error: (Did you mean 'typing.Callable'?)
 
 [case testInvalidWithTarget]
 def f(): pass
@@ -1321,22 +1321,22 @@ with f() as 1: pass  # E: Invalid assignment target
 from typing import typevar
 t = typevar('t')
 [out]
-main, line 1: Module has no attribute 'typevar' (it's now called 'typing.TypeVar')
-main, line 2: Name 'typevar' is not defined
-main, line 2: (Did you mean 'typing.TypeVar'?)
+main:1: error: Module has no attribute 'typevar' (it's now called 'typing.TypeVar')
+main:2: error: Name 'typevar' is not defined
+main:2: error: (Did you mean 'typing.TypeVar'?)
 --' (this fixes syntax highlighting)
 
 [case testUseObsoleteNameForTypeVar2]
 t = typevar('t')
 [out]
-main, line 1: Name 'typevar' is not defined
-main, line 1: (Did you mean 'typing.TypeVar'?)
+main:1: error: Name 'typevar' is not defined
+main:1: error: (Did you mean 'typing.TypeVar'?)
 
 [case testUseObsoleteNameForTypeVar3]
 import typing
 t = typing.typevar('t')
 [out]
-main, line 2: Module has no attribute 'typevar' (it's now called 'typing.TypeVar')
+main:2: error: Module has no attribute 'typevar' (it's now called 'typing.TypeVar')
 --' (work around syntax highlighting :-/)
 
 [case testInvalidTypeAnnotation]
@@ -1344,16 +1344,16 @@ import typing
 def f() -> None:
     1[2] = 1  # type: int
 [out]
-main: In function "f":
-main, line 3: Unexpected type declaration
+main: note: In function "f":
+main:3: error: Unexpected type declaration
 
 [case testInvalidTypeAnnotation2]
 import typing
 def f() -> None:
     f() = 1  # type: int
 [out]
-main: In function "f":
-main, line 3: Invalid assignment target
+main: note: In function "f":
+main:3: error: Invalid assignment target
 
 [case testInvalidReferenceToAttributeOfOuterClass]
 class A:

--- a/mypy/test/data/semanal-modules.test
+++ b/mypy/test/data/semanal-modules.test
@@ -771,8 +771,8 @@ import m.x
 [file m/x.py]
 from .x import nonexistent
 [out]
-In module imported in main, line 1:
-tmp/m/x.py, line 1: Module has no attribute 'nonexistent'
+main:1: note: In module imported here:
+tmp/m/x.py:1: error: Module has no attribute 'nonexistent'
 
 [case testImportFromSameModule]
 import m.x
@@ -780,5 +780,5 @@ import m.x
 [file m/x.py]
 from m.x import nonexistent
 [out]
-In module imported in main, line 1:
-tmp/m/x.py, line 1: Module has no attribute 'nonexistent'
+main:1: note: In module imported here:
+tmp/m/x.py:1: error: Module has no attribute 'nonexistent'

--- a/mypy/test/data/semanal-namedtuple.test
+++ b/mypy/test/data/semanal-namedtuple.test
@@ -140,5 +140,5 @@ class B(A): pass
 class A(NamedTuple('N', [1])): pass
 class B(A): pass
 [out]
-main, line 1: Name 'NamedTuple' is not defined
-main, line 1: Invalid base class
+main:1: error: Name 'NamedTuple' is not defined
+main:1: error: Invalid base class


### PR DESCRIPTION
There is a standard format for errors and warnings. Using it means better integration for other tools.

```
file:line:col: level: message [-option]
```

`file` must be absolute or relative to the current working directory.
`line` is 1-based and any line without it is not considered for the protocol.
`col` is 1-based may be omitted. It should probably always be omitted if something like C's `#file` is used to replace the file/line that the compiler sees with the file/line of the program that emitted that source file.
`level` may be `error` or `warning` to receive special handling in editors, or anything else (commonly `note` for multi-location errors/warnings) or omitted to not be collected specially. Essentially this is part of `message` in those cases. 
`[-option]` is the command-line argument used to enable a warning, and may be omitted. This is essentially part of `message` for all programmatic purposes, but useful for humans.

Programs such as gcc and make produce this format; IDEs and text editors such as vim and kate consume it. There are doubtless uncountably many more programs that also use the same protocol.