### PR TITLE
Use `__slots__` in `typing` module

### DIFF
--- a/lib-typing/3.2/typing.py
+++ b/lib-typing/3.2/typing.py
@@ -128,6 +128,8 @@ class TypingMeta(type):
 class Final:
     """Mix-in class to prevent instantiation."""
 
+    __slots__ = ()
+
     def __new__(self, *args, **kwds):
         raise TypeError("Cannot instantiate %r" % self.__class__)
 
@@ -210,6 +212,8 @@ class _TypeAlias:
     some arbitrary class C) raises TypeError rather than returning
     False.
     """
+
+    __slots__ = ('name', 'type_var', 'impl_type', 'type_checker')
 
     def __new__(cls, *args, **kwds):
         """Constructor.
@@ -348,6 +352,8 @@ class Any(Final, metaclass=AnyMeta, _root=True):
     - Any class is a subclass of Any.
     - As a special case, Any and object are subclasses of each other.
     """
+
+    __slots__ = ()
 
 
 class TypeVar(TypingMeta, metaclass=TypingMeta, _root=True):
@@ -645,6 +651,8 @@ class Optional(Final, metaclass=OptionalMeta, _root=True):
     Optional[X] is equivalent to Union[X, type(None)].
     """
 
+    __slots__ = ()
+
 
 class TupleMeta(TypingMeta):
     """Metaclass for Tuple."""
@@ -753,6 +761,8 @@ class Tuple(Final, metaclass=TupleMeta, _root=True):
 
     To specify a variable-length tuple of homogeneous type, use Sequence[T].
     """
+
+    __slots__ = ()
 
 
 class CallableMeta(TypingMeta):
@@ -899,6 +909,8 @@ class Callable(Final, metaclass=CallableMeta, _root=True):
     There is no syntax to indicate optional or keyword arguments,
     such function types are rarely used as callback types.
     """
+
+    __slots__ = ()
 
 
 def _gorg(a):
@@ -1109,6 +1121,8 @@ class Generic(metaclass=GenericMeta):
           # Same body as above.
     """
 
+    __slots__ = ()
+
     def __new__(cls, *args, **kwds):
         next_in_mro = object
         # Look for the last occurrence of Generic or Generic[...].
@@ -1272,6 +1286,7 @@ class _ProtocolMeta(GenericMeta):
                         attr != '__abstractmethods__' and
                         attr != '_is_protocol' and
                         attr != '__dict__' and
+                        attr != '__slots__' and
                         attr != '_get_protocol_attrs' and
                         attr != '__parameters__' and
                         attr != '__origin__' and
@@ -1289,6 +1304,8 @@ class _Protocol(metaclass=_ProtocolMeta):
     such as Hashable).
     """
 
+    __slots__ = ()
+
     _is_protocol = True
 
 
@@ -1299,14 +1316,15 @@ Hashable = collections_abc.Hashable  # Not generic.
 
 
 class Iterable(Generic[T_co], extra=collections_abc.Iterable):
-    pass
+    __slots__ = ()
 
 
 class Iterator(Iterable[T_co], extra=collections_abc.Iterator):
-    pass
+    __slots__ = ()
 
 
 class SupportsInt(_Protocol):
+    __slots__ = ()
 
     @abstractmethod
     def __int__(self) -> int:
@@ -1314,6 +1332,7 @@ class SupportsInt(_Protocol):
 
 
 class SupportsFloat(_Protocol):
+    __slots__ = ()
 
     @abstractmethod
     def __float__(self) -> float:
@@ -1321,6 +1340,7 @@ class SupportsFloat(_Protocol):
 
 
 class SupportsComplex(_Protocol):
+    __slots__ = ()
 
     @abstractmethod
     def __complex__(self) -> complex:
@@ -1328,6 +1348,7 @@ class SupportsComplex(_Protocol):
 
 
 class SupportsBytes(_Protocol):
+    __slots__ = ()
 
     @abstractmethod
     def __bytes__(self) -> bytes:
@@ -1335,6 +1356,7 @@ class SupportsBytes(_Protocol):
 
 
 class SupportsAbs(_Protocol[T]):
+    __slots__ = ()
 
     @abstractmethod
     def __abs__(self) -> T:
@@ -1342,6 +1364,7 @@ class SupportsAbs(_Protocol[T]):
 
 
 class SupportsRound(_Protocol[T]):
+    __slots__ = ()
 
     @abstractmethod
     def __round__(self, ndigits: int = 0) -> T:
@@ -1349,6 +1372,7 @@ class SupportsRound(_Protocol[T]):
 
 
 class Reversible(_Protocol[T]):
+    __slots__ = ()
 
     @abstractmethod
     def __reversed__(self) -> 'Iterator[T]':
@@ -1359,7 +1383,7 @@ Sized = collections_abc.Sized  # Not generic.
 
 
 class Container(Generic[T_co], extra=collections_abc.Container):
-    pass
+    __slots__ = ()
 
 
 # Callable was defined earlier.
@@ -1367,33 +1391,33 @@ class Container(Generic[T_co], extra=collections_abc.Container):
 
 class AbstractSet(Sized, Iterable[T_co], Container[T_co],
                   extra=collections_abc.Set):
-    pass
+    __slots__ = ()
 
 
 class MutableSet(AbstractSet[T], extra=collections_abc.MutableSet):
-    pass
+    __slots__ = ()
 
 
 class Mapping(Sized, Iterable[KT_co], Container[KT_co], Generic[KT_co, VT_co],
               extra=collections_abc.Mapping):
-    pass
+    __slots__ = ()
 
 
 class MutableMapping(Mapping[KT, VT], extra=collections_abc.MutableMapping):
-    pass
+    __slots__ = ()
 
 
 class Sequence(Sized, Iterable[T_co], Container[T_co],
                extra=collections_abc.Sequence):
-    pass
+    __slots__ = ()
 
 
 class MutableSequence(Sequence[T], extra=collections_abc.MutableSequence):
-    pass
+    __slots__ = ()
 
 
 class ByteString(Sequence[int], extra=collections_abc.ByteString):
-    pass
+    __slots__ = ()
 
 
 ByteString.register(type(memoryview(b'')))
@@ -1412,6 +1436,7 @@ class _ListMeta(GenericMeta):
 
 
 class List(list, MutableSequence[T], metaclass=_ListMeta):
+    __slots__ = ()
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, List):
@@ -1433,6 +1458,7 @@ class _SetMeta(GenericMeta):
 
 
 class Set(set, MutableSet[T], metaclass=_SetMeta):
+    __slots__ = ()
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Set):
@@ -1461,6 +1487,7 @@ class _FrozenSetMeta(_SetMeta):
 
 
 class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta):
+    __slots__ = ()
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, FrozenSet):
@@ -1470,22 +1497,22 @@ class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta):
 
 
 class MappingView(Sized, Iterable[T_co], extra=collections_abc.MappingView):
-    pass
+    __slots__ = ()
 
 
 class KeysView(MappingView[KT_co], AbstractSet[KT_co],
                extra=collections_abc.KeysView):
-    pass
+    __slots__ = ()
 
 
 # TODO: Enable Set[Tuple[KT_co, VT_co]] instead of Generic[KT_co, VT_co].
 class ItemsView(MappingView, Generic[KT_co, VT_co],
                 extra=collections_abc.ItemsView):
-    pass
+    __slots__ = ()
 
 
 class ValuesView(MappingView[VT_co], extra=collections_abc.ValuesView):
-    pass
+    __slots__ = ()
 
 
 class _DictMeta(GenericMeta):
@@ -1502,6 +1529,7 @@ class _DictMeta(GenericMeta):
 
 
 class Dict(dict, MutableMapping[KT, VT], metaclass=_DictMeta):
+    __slots__ = ()
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Dict):
@@ -1521,6 +1549,7 @@ else:
 
 class Generator(Iterator[T_co], Generic[T_co, T_contra, V_co],
                 extra=_G_base):
+    __slots__ = ()
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Generator):
@@ -1563,6 +1592,8 @@ class IO(Generic[AnyStr]):
     pervasive in the interface; however we currently do not offer a
     way to track the other distinctions in the type system.
     """
+
+    __slots__ = ()
 
     @abstractproperty
     def mode(self) -> str:
@@ -1648,6 +1679,8 @@ class IO(Generic[AnyStr]):
 class BinaryIO(IO[bytes]):
     """Typed version of the return of open() in binary mode."""
 
+    __slots__ = ()
+
     @abstractmethod
     def write(self, s: Union[bytes, bytearray]) -> int:
         pass
@@ -1659,6 +1692,8 @@ class BinaryIO(IO[bytes]):
 
 class TextIO(IO[str]):
     """Typed version of the return of open() in text mode."""
+
+    __slots__ = ()
 
     @abstractproperty
     def buffer(self) -> BinaryIO:


### PR DESCRIPTION
This is primarily useful for subclassing `Generic[T]`, but it's easiest
to do it all at once.