### PR TITLE
North American spelling of "analyze" throughout project

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -284,7 +284,7 @@ def meet_frames(*frames: Frame) -> Frame:
 class TypeChecker(NodeVisitor[Type]):
     """Mypy type checker.
 
-    Type check mypy source files that have been semantically analysed.
+    Type check mypy source files that have been semantically analyzed.
     """
 
     # Target Python major version
@@ -582,7 +582,7 @@ class TypeChecker(NodeVisitor[Type]):
                     method, other_method, defn)
                 return
 
-            typ2 = self.expr_checker.analyse_external_member_access(
+            typ2 = self.expr_checker.analyze_external_member_access(
                 other_method, arg_type, defn)
             self.check_overlapping_op_methods(
                 typ, method, defn.info,
@@ -678,7 +678,7 @@ class TypeChecker(NodeVisitor[Type]):
         other_method = '__' + method[3:]
         if cls.has_readable_member(other_method):
             instance = self_type(cls)
-            typ2 = self.expr_checker.analyse_external_member_access(
+            typ2 = self.expr_checker.analyze_external_member_access(
                 other_method, instance, defn)
             fail = False
             if isinstance(typ2, FunctionLike):
@@ -1136,11 +1136,11 @@ class TypeChecker(NodeVisitor[Type]):
         elif isinstance(lvalue, IndexExpr):
             index_lvalue = lvalue
         elif isinstance(lvalue, MemberExpr):
-            lvalue_type = self.expr_checker.analyse_ordinary_member_access(lvalue,
+            lvalue_type = self.expr_checker.analyze_ordinary_member_access(lvalue,
                                                                  True)
             self.store_type(lvalue, lvalue_type)
         elif isinstance(lvalue, NameExpr):
-            lvalue_type = self.expr_checker.analyse_ref_expr(lvalue)
+            lvalue_type = self.expr_checker.analyze_ref_expr(lvalue)
             self.store_type(lvalue, lvalue_type)
         elif isinstance(lvalue, TupleExpr) or isinstance(lvalue, ListExpr):
             lv = cast(Union[TupleExpr, ListExpr], lvalue)
@@ -1255,7 +1255,7 @@ class TypeChecker(NodeVisitor[Type]):
         The lvalue argument is the base[index] expression.
         """
         basetype = self.accept(lvalue.base)
-        method_type = self.expr_checker.analyse_external_member_access(
+        method_type = self.expr_checker.analyze_external_member_access(
             '__setitem__', basetype, context)
         lvalue.method_type = method_type
         self.expr_checker.check_call(method_type, [lvalue.index, rvalue],
@@ -1349,7 +1349,7 @@ class TypeChecker(NodeVisitor[Type]):
                 self.function_stack[-1].is_coroutine = True  # Set the function as coroutine
             elif is_subtype(type_func, self.named_type('typing.Iterable')):
                 # If it's and Iterable-Like, let's check the types.
-                # Maybe just check if have __iter__? (like in analyse_iterable)
+                # Maybe just check if have __iter__? (like in analyze_iterable)
                 self.check_iterable_yield_from(s)
             else:
                 self.msg.yield_from_invalid_operand_type(type_func, s)
@@ -1564,8 +1564,8 @@ class TypeChecker(NodeVisitor[Type]):
 
     def visit_for_stmt(self, s: ForStmt) -> Type:
         """Type check a for statement."""
-        item_type = self.analyse_iterable_item_type(s.expr)
-        self.analyse_index_variables(s.index, item_type, s)
+        item_type = self.analyze_iterable_item_type(s.expr)
+        self.analyze_index_variables(s.index, item_type, s)
         self.binder.push_frame()
         self.binder.push_loop_frame()
         self.accept_in_frame(s.body, repeat_till_fixed=True)
@@ -1574,7 +1574,7 @@ class TypeChecker(NodeVisitor[Type]):
             self.accept(s.else_body)
         self.binder.pop_frame(False, True)
 
-    def analyse_iterable_item_type(self, expr: Node) -> Type:
+    def analyze_iterable_item_type(self, expr: Node) -> Type:
         """Analyse iterable expression and return iterator item type."""
         iterable = self.accept(expr)
 
@@ -1595,18 +1595,18 @@ class TypeChecker(NodeVisitor[Type]):
                                expr, messages.ITERABLE_EXPECTED)
 
             echk = self.expr_checker
-            method = echk.analyse_external_member_access('__iter__', iterable,
+            method = echk.analyze_external_member_access('__iter__', iterable,
                                                          expr)
             iterator = echk.check_call(method, [], [], expr)[0]
             if self.pyversion >= 3:
                 nextmethod = '__next__'
             else:
                 nextmethod = 'next'
-            method = echk.analyse_external_member_access(nextmethod, iterator,
+            method = echk.analyze_external_member_access(nextmethod, iterator,
                                                          expr)
             return echk.check_call(method, [], [], expr)[0]
 
-    def analyse_index_variables(self, index: Node, item_type: Type,
+    def analyze_index_variables(self, index: Node, item_type: Type,
                                 context: Context) -> None:
         """Type check or infer for loop or list comprehension index vars."""
         self.check_assignment(index, self.temp_node(item_type, context))
@@ -1649,11 +1649,11 @@ class TypeChecker(NodeVisitor[Type]):
         echk = self.expr_checker
         for expr, target in zip(s.expr, s.target):
             ctx = self.accept(expr)
-            enter = echk.analyse_external_member_access('__enter__', ctx, expr)
+            enter = echk.analyze_external_member_access('__enter__', ctx, expr)
             obj = echk.check_call(enter, [], [], expr)[0]
             if target:
                 self.check_assignment(target, self.temp_node(obj, expr))
-            exit = echk.analyse_external_member_access('__exit__', ctx, expr)
+            exit = echk.analyze_external_member_access('__exit__', ctx, expr)
             arg = self.temp_node(AnyType(), expr)
             echk.check_call(exit, [arg] * 3, [nodes.ARG_POS] * 3, expr)
         self.accept(s.body)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -17,7 +17,7 @@ from mypy import messages
 from mypy import subtypes
 
 
-def analyse_member_access(name: str, typ: Type, node: Context, is_lvalue: bool,
+def analyze_member_access(name: str, typ: Type, node: Context, is_lvalue: bool,
                           is_super: bool,
                           builtin_type: Callable[[str], Instance],
                           msg: MessageBuilder, override_info: TypeInfo = None,
@@ -58,7 +58,7 @@ def analyse_member_access(name: str, typ: Type, node: Context, is_lvalue: bool,
                 method_type_with_fallback(method, builtin_type('builtins.function')), typ)
         else:
             # Not a method.
-            return analyse_member_var_access(name, typ, info, node,
+            return analyze_member_var_access(name, typ, info, node,
                                              is_lvalue, is_super, builtin_type,
                                              msg,
                                              report_type=report_type)
@@ -68,14 +68,14 @@ def analyse_member_access(name: str, typ: Type, node: Context, is_lvalue: bool,
     elif isinstance(typ, UnionType):
         # The base object has dynamic type.
         msg.disable_type_names += 1
-        results = [analyse_member_access(name, subtype, node, is_lvalue,
+        results = [analyze_member_access(name, subtype, node, is_lvalue,
                                          is_super, builtin_type, msg)
                    for subtype in typ.items]
         msg.disable_type_names -= 1
         return UnionType.make_simplified_union(results)
     elif isinstance(typ, TupleType):
         # Actually look up from the fallback instance type.
-        return analyse_member_access(name, typ.fallback, node, is_lvalue,
+        return analyze_member_access(name, typ.fallback, node, is_lvalue,
                                      is_super, builtin_type, msg)
     elif (isinstance(typ, FunctionLike) and
           cast(FunctionLike, typ).is_type_obj()):
@@ -83,30 +83,30 @@ def analyse_member_access(name: str, typ: Type, node: Context, is_lvalue: bool,
         # TODO super?
         sig = cast(FunctionLike, typ)
         itype = cast(Instance, sig.items()[0].ret_type)
-        result = analyse_class_attribute_access(itype, name, node, is_lvalue, builtin_type, msg)
+        result = analyze_class_attribute_access(itype, name, node, is_lvalue, builtin_type, msg)
         if result:
             return result
         # Look up from the 'type' type.
-        return analyse_member_access(name, sig.fallback, node, is_lvalue, is_super,
+        return analyze_member_access(name, sig.fallback, node, is_lvalue, is_super,
                                      builtin_type, msg, report_type=report_type)
     elif isinstance(typ, FunctionLike):
         # Look up from the 'function' type.
-        return analyse_member_access(name, typ.fallback, node, is_lvalue, is_super,
+        return analyze_member_access(name, typ.fallback, node, is_lvalue, is_super,
                                      builtin_type, msg, report_type=report_type)
     elif isinstance(typ, TypeVarType):
-        return analyse_member_access(name, typ.upper_bound, node, is_lvalue, is_super,
+        return analyze_member_access(name, typ.upper_bound, node, is_lvalue, is_super,
                                      builtin_type, msg, report_type=report_type)
     return msg.has_no_attr(report_type, name, node)
 
 
-def analyse_member_var_access(name: str, itype: Instance, info: TypeInfo,
+def analyze_member_var_access(name: str, itype: Instance, info: TypeInfo,
                               node: Context, is_lvalue: bool, is_super: bool,
                               builtin_type: Callable[[str], Instance],
                               msg: MessageBuilder,
                               report_type: Type = None) -> Type:
     """Analyse attribute access that does not target a method.
 
-    This is logically part of analyse_member_access and the arguments are
+    This is logically part of analyze_member_access and the arguments are
     similar.
     """
     # It was not a method. Try looking up a variable.
@@ -143,7 +143,7 @@ def analyze_var(name: str, var: Var, itype: Instance, info: TypeInfo, node: Cont
                is_lvalue: bool, msg: MessageBuilder) -> Type:
     """Analyze access to an attribute via a Var node.
 
-    This is conceptually part of analyse_member_access and the arguments are similar.
+    This is conceptually part of analyze_member_access and the arguments are similar.
     """
     # Found a member variable.
     itype = map_instance_to_supertype(itype, var.info)
@@ -202,7 +202,7 @@ def check_method_type(functype: FunctionLike, itype: Instance,
                 msg.invalid_method_type(item, context)
 
 
-def analyse_class_attribute_access(itype: Instance,
+def analyze_class_attribute_access(itype: Instance,
                                    name: str,
                                    context: Context,
                                    is_lvalue: bool,

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -57,7 +57,7 @@ class StringFormatterChecker:
         expression: str % replacements
         """
         specifiers = self.parse_conversion_specifiers(str.value)
-        has_mapping_keys = self.analyse_conversion_specifiers(specifiers, str)
+        has_mapping_keys = self.analyze_conversion_specifiers(specifiers, str)
         if has_mapping_keys == None:
             pass # Error was reported
         elif has_mapping_keys:
@@ -82,7 +82,7 @@ class StringFormatterChecker:
             specifiers.append(ConversionSpecifier(key, flags, width, precision, type))
         return specifiers
 
-    def analyse_conversion_specifiers(self, specifiers: List[ConversionSpecifier],
+    def analyze_conversion_specifiers(self, specifiers: List[ConversionSpecifier],
                                       context: Context) -> bool:
         has_star = any(specifier.has_star() for specifier in specifiers)
         has_key = any(specifier.has_key() for specifier in specifiers)

--- a/mypy/test/data/check-classes.test
+++ b/mypy/test/data/check-classes.test
@@ -1183,4 +1183,4 @@ a = 0 # E: Incompatible types in assignment (expression has type "int", variable
 -- TODO
 --   attribute inherited from superclass; assign in __init__
 --   refer to attribute before type has been inferred (the initialization in
---   __init__ has not been analysed)
+--   __init__ has not been analyzed)

--- a/mypy/test/data/fixtures/transform.py
+++ b/mypy/test/data/fixtures/transform.py
@@ -18,8 +18,8 @@ class float: pass
 
 # The functions below are special functions used in test cases; their
 # implementations are actually in the __dynchk module, but they are defined
-# here so that the semantic analyser and the type checker are happy without
-# having to analyse the entire __dynchk module all the time.
+# here so that the semantic analyzer and the type checker are happy without
+# having to analyze the entire __dynchk module all the time.
 #
 # The transformation implementation has special case handling for these
 # functions; it's a bit ugly but it works for now.

--- a/mypy/test/data/semanal-classes.test
+++ b/mypy/test/data/semanal-classes.test
@@ -1,4 +1,4 @@
--- Test cases related to classes for the semantic analyser.
+-- Test cases related to classes for the semantic analyzer.
 
 [case testSimpleClass]
 class A: pass

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -13,7 +13,7 @@ from mypy.errors import CompileError
 from mypy.nodes import TypeInfo
 
 
-# Semantic analyser test cases: dump parse tree
+# Semantic analyzer test cases: dump parse tree
 
 # Semantic analysis test case description files.
 semanal_files = ['semanal-basic.test',
@@ -75,7 +75,7 @@ def test_semanal(testcase):
         'Invalid semantic analyzer output ({}, line {})'.format(testcase.file,
                                                                 testcase.line))
 
-# Semantic analyser error test cases
+# Semantic analyzer error test cases
 
 # Paths to files containing test case descriptions.
 semanal_error_files = ['semanal-errors.test']

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -18,7 +18,7 @@ from mypy import nodes
 type_constructors = ['typing.Tuple', 'typing.Union', 'typing.Callable']
 
 
-def analyse_type_alias(node: Node,
+def analyze_type_alias(node: Node,
                        lookup_func: Callable[[str, Context], SymbolTableNode],
                        lookup_fqn_func: Callable[[str], SymbolTableNode],
                        fail_func: Callable[[str, Context], None]) -> Type:
@@ -51,8 +51,8 @@ def analyse_type_alias(node: Node,
     except TypeTranslationError:
         fail_func('Invalid type alias', node)
         return None
-    analyser = TypeAnalyser(lookup_func, lookup_fqn_func, fail_func)
-    return type.accept(analyser)
+    analyzer = TypeAnalyser(lookup_func, lookup_fqn_func, fail_func)
+    return type.accept(analyzer)
 
 
 class TypeAnalyser(TypeVisitor[Type]):
@@ -148,7 +148,7 @@ class TypeAnalyser(TypeVisitor[Type]):
         return t
 
     def visit_type_var(self, t: TypeVarType) -> Type:
-        raise RuntimeError('TypeVarType is already analysed')
+        raise RuntimeError('TypeVarType is already analyzed')
 
     def visit_callable_type(self, t: CallableType) -> Type:
         res = CallableType(self.anal_array(t.arg_types),


### PR DESCRIPTION
I hope we don't mind trivial and pedantic pull requests! [It turns out](http://grammarist.com/spelling/analyse-analyze/) *analyse* is the British spelling, while "analyze" is preferred in North America. Interesting! If we prefer the NA spelling, here's a PR.

For what it's worth, there are [23 occurrences](https://github.com/python/cpython/search?utf8=%E2%9C%93&q=analyze&type=Code) of "analyze" in the CPython source and only [1 occurrence](https://github.com/python/cpython/search?utf8=%E2%9C%93&q=analyse&type=Code) of "analyse".