### PR TITLE
Catch incomplete TypeVisitor implementations

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -437,7 +437,7 @@ class BuildManager:
         for state in self.states:
             if state.id == module:
                 return state
-        raise RuntimeError('%s not found' % str)
+        raise RuntimeError('%s not found' % module)
 
     def all_imported_modules_in_file(self,
                                      file: MypyFile) -> List[Tuple[str, int]]:

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -273,6 +273,12 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             res.extend(infer_constraints(t, AnyType(), self.direction))
         return res
 
+    def visit_overloaded(self, type: Overloaded) -> List[Constraint]:
+        res = []  # type: List[Constraint]
+        for t in type.items():
+            res.extend(infer_constraints(t, self.actual, self.direction))
+        return res
+
 
 def negate_constraints(constraints: List[Constraint]) -> List[Constraint]:
     res = []  # type: List[Constraint]

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -2,7 +2,7 @@ from typing import List, cast
 
 from mypy.types import (
     Type, UnboundType, ErrorType, AnyType, NoneTyp, Void, TupleType, UnionType, CallableType,
-    TypeVarType, Instance, TypeVisitor, ErasedType, TypeList
+    TypeVarType, Instance, TypeVisitor, ErasedType, TypeList, Overloaded
 )
 
 
@@ -89,5 +89,12 @@ class SameTypeVisitor(TypeVisitor[bool]):
         # XXX This is a test for syntactic equality, not equivalence
         if isinstance(self.right, UnionType):
             return is_same_types(left.items, cast(UnionType, self.right).items)
+        else:
+            return False
+
+    def visit_overloaded(self, left: Overloaded) -> bool:
+        if isinstance(self.right, Overloaded):
+            return is_same_types(cast(List[Type], left.items()),
+                                 cast(List[Type], cast(Overloaded, self.right).items()))
         else:
             return False

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -333,3 +333,6 @@ class TypeAnalyserPass3(TypeVisitor[None]):
 
     def visit_type_var(self, t: TypeVarType) -> None:
         pass
+
+    def visit_star_type(self, t: StarType) -> None:
+        pass

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -492,6 +492,7 @@ class TypeVisitor(Generic[T]):
     The parameter T is the return type of the visit methods.
     """
 
+    @abstractmethod
     def visit_unbound_type(self, t: UnboundType) -> T:
         pass
 
@@ -501,41 +502,49 @@ class TypeVisitor(Generic[T]):
     def visit_error_type(self, t: ErrorType) -> T:
         pass
 
+    @abstractmethod
     def visit_any(self, t: AnyType) -> T:
         pass
 
+    @abstractmethod
     def visit_void(self, t: Void) -> T:
         pass
 
+    @abstractmethod
     def visit_none_type(self, t: NoneTyp) -> T:
         pass
 
     def visit_erased_type(self, t: ErasedType) -> T:
         pass
 
+    @abstractmethod
     def visit_type_var(self, t: TypeVarType) -> T:
         pass
 
+    @abstractmethod
     def visit_instance(self, t: Instance) -> T:
         pass
 
+    @abstractmethod
     def visit_callable_type(self, t: CallableType) -> T:
         pass
 
     def visit_overloaded(self, t: Overloaded) -> T:
         pass
 
+    @abstractmethod
     def visit_tuple_type(self, t: TupleType) -> T:
         pass
 
     def visit_star_type(self, t: StarType) -> T:
         pass
 
+    @abstractmethod
     def visit_union_type(self, t: UnionType) -> T:
         pass
 
     def visit_ellipsis_type(self, t: EllipsisType) -> T:
-        assert False               # XXX catch visitors that don't have this implemented yet
+        pass
 
 
 class TypeTranslator(TypeVisitor[Type]):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -624,6 +624,10 @@ class TypeTranslator(TypeVisitor[Type]):
                             variables: List[TypeVarDef]) -> List[TypeVarDef]:
         return variables
 
+    def visit_overloaded(self, type: Overloaded) -> Type:
+        items = [t.accept(self) for t in type.items()]  # type: ignore
+        return Overloaded(items=cast(List[CallableType], items))
+
 
 class TypeStrVisitor(TypeVisitor[str]):
     """Visitor for pretty-printing types into strings.

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -492,15 +492,21 @@ class TypeVisitor(Generic[T]):
     The parameter T is the return type of the visit methods.
     """
 
+    def _notimplemented_helper(self) -> NotImplementedError:
+        return NotImplementedError("Method visit_type_list not implemented in "
+                                   + "'{}'\n".format(type(self).__name__)
+                                   + "This is a known bug, track development in "
+                                   + "'https://github.com/JukkaL/mypy/issues/730'")
+
     @abstractmethod
     def visit_unbound_type(self, t: UnboundType) -> T:
         pass
 
     def visit_type_list(self, t: TypeList) -> T:
-        pass
+        raise self._notimplemented_helper()
 
     def visit_error_type(self, t: ErrorType) -> T:
-        pass
+        raise self._notimplemented_helper()
 
     @abstractmethod
     def visit_any(self, t: AnyType) -> T:
@@ -515,7 +521,7 @@ class TypeVisitor(Generic[T]):
         pass
 
     def visit_erased_type(self, t: ErasedType) -> T:
-        pass
+        raise self._notimplemented_helper()
 
     @abstractmethod
     def visit_type_var(self, t: TypeVarType) -> T:
@@ -530,21 +536,21 @@ class TypeVisitor(Generic[T]):
         pass
 
     def visit_overloaded(self, t: Overloaded) -> T:
-        pass
+        raise self._notimplemented_helper()
 
     @abstractmethod
     def visit_tuple_type(self, t: TupleType) -> T:
         pass
 
     def visit_star_type(self, t: StarType) -> T:
-        pass
+        raise self._notimplemented_helper()
 
     @abstractmethod
     def visit_union_type(self, t: UnionType) -> T:
         pass
 
     def visit_ellipsis_type(self, t: EllipsisType) -> T:
-        pass
+        raise self._notimplemented_helper()
 
 
 class TypeTranslator(TypeVisitor[Type]):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -824,6 +824,9 @@ class TypeQuery(TypeVisitor[bool]):
     def visit_union_type(self, t: UnionType) -> bool:
         return self.query_types(t.items)
 
+    def visit_overloaded(self, t: Overloaded) -> bool:
+        return self.query_types(cast(List[Type], t.items()))
+
     def query_types(self, types: List[Type]) -> bool:
         """Perform a query for a list of types.
 


### PR DESCRIPTION
Use the `@abstractmethod` decorator on abstract methods. Part of #730

This breaks all tests as the `@abstractmethod` raises a runtime exception on instantiation of a subclass with unimplemented abstract methods. We need to provide complete implementations for these in order to get the tests to pass.

Subclasses with incomplete implementations are:

~~~
EraseTypeVisitor (mypy/erasetype.py: 26)
    visit_ellipsis_type()
    visit_star_type()

SameTypeVisitor(mypy/sametype.py: 29)
    visit_overloaded()
    visit_ellipsis_type()
    visit_star_type()

ExpandTypeVisitor(mypy/expandtype.py: 35)
    visit_ellipsis_type()
    visit_star_type()

SubtypeVisitor(mypy/subtypes.py: 44)
    visit_ellipsis_type()
    visit_star_type()

TypeAnalyser(mypy/typeanal.py: 58)
    visit_error_type()
    visit_overloaded()
    visit_ellipsis_type()
    visit_star_type()

TypeJoinVisitor(mypy/join.py: 70)
    visit_overloaded()
    visit_ellipsis_type()
    visit_star_type()

TypeMeetVisitor(mypy/meet.py: 77)
    visit_ellipsis_type()
    visit_star_type()

ConstraintBuilderVisitor(mypy/constraints.py: 125)
    visit_error_type()
    visit_overloaded()
    visit_ellipsis_type()
    visit_star_type()
    visit_type_list()

TypeQuery(mypy/types.py: 760)
    visit_overloaded()
    visit_ellipsis_type()

subclasses of TypeQuery:
    HasAnyQuery(mypy/stats.py: 223)
    HasAnyQuery2(mypy/stats.py: 241)
    ArgInferSecondpassQuery(mypy/checkexpr.py: 1375)
    HasTypeVarQuery(mypy/checkexpr.py: 1389)
    HasErasedComponentsQuery(mypy/checkexpr.py: 1402)

TypeAnalyserPass3(mypy/typeanal.py: 234)
    visit_error_type()
    visit_overloaded()
    visit_ellipsis_type()
    visit_star_type()
    visit_type_list()
~~~
