### PR TITLE
Permit global symbol definition overwriting if the type is the same

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1878,7 +1878,7 @@ class SemanticAnalyzer(NodeVisitor):
                              existing.node != node.node):
                 # Modules can be imported multiple times to support import
                 # of multiple submodules of a package (e.g. a.x and a.y).
-                if not is_same_type(existing.type, node.type):
+                if not (existing.type and node.type and is_same_type(existing.type, node.type)):
                     # Only report an error if the symbol collision provides a different type.
                     self.name_already_defined(name, context)
             self.globals[name] = node

--- a/mypy/test/data/check-modules.test
+++ b/mypy/test/data/check-modules.test
@@ -466,7 +466,25 @@ import m.a
 [file m/a.py]
 [out]
 
-[case testStarImportOverridingOtherImports-skip]
+[case testStarImportOverlapping]
+from m1 import *
+from m2 import *
+j = ''
+[file m1.py]
+x = 1
+[file m2.py]
+x = 1
+
+[case testStarImportOverlappingMismatch]
+from m1 import *
+from m2 import * # E: Name 'x' already defined
+j = ''
+[file m1.py]
+x = ''
+[file m2.py]
+x = 1
+
+[case testStarImportOverridingLocalImports-skip]
 from m1 import *
 from m2 import *
 x = '' # E: TODO (cannot assign str to int)


### PR DESCRIPTION
This doesn't resolve the initial test case, as the symbol initially exists without a type due to the first pass, but our problem case doesn't require that, so I made the 'same types imported from different modules' case pass.

No idea if this is the right approach; mostly just playing.