### PR TITLE
Allow statements of the form `raise BaseException, "message", traceback`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1499,7 +1499,12 @@ class TypeChecker(NodeVisitor[Type]):
                 if base in typeinfo.mro:
                     # Good!
                     return None
-                # Else fall back to the check below (which will fail).
+                # Else fall back to the checks below (which will fail).
+        if isinstance(typ, TupleType):
+            # allow `raise type, value, traceback`
+            # https://docs.python.org/2/reference/simple_stmts.html#the-raise-statement
+            if len(typ.items) in (2, 3):
+                return None
         self.check_subtype(typ,
                            self.named_type('builtins.BaseException'), s,
                            messages.INVALID_EXCEPTION)

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -313,6 +313,13 @@ raise object # E: Exception must be derived from BaseException
 raise f # E: Exception must be derived from BaseException
 [builtins fixtures/exception.py]
 
+[case testRaiseTuple]
+import typing
+raise BaseException, "a"
+raise BaseException, "a", None
+raise BaseException, "a", None, None # E: Exception must be derived from BaseException
+[builtins fixtures/exception.py]
+
 [case testRaiseFromStatement]
 
 e = None # type: BaseException


### PR DESCRIPTION
Worked against Dropbox code and unit tests.
```
$ python3 tests.py
2240 test cases run, 15 skipped, all passed.
*** OK ***
```

Closes #811