### PR TITLE
Include types in error message "No overload variant of ... of ... matches argument types"

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -577,7 +577,7 @@ class ExpressionChecker:
                     match.append(typ)
                 best_match = max(best_match, similarity)
         if not match:
-            messages.no_variant_matches_arguments(overload, context)
+            messages.no_variant_matches_arguments(overload, arg_types, context)
             return AnyType()
         else:
             if len(match) == 1:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -467,13 +467,13 @@ class MessageBuilder:
             self.fail('{} does not return a value'.format(
                 capitalize((cast(Void, void_type)).source)), context)
 
-    def no_variant_matches_arguments(self, overload: Overloaded,
+    def no_variant_matches_arguments(self, overload: Overloaded, arg_types: List[Type],
                                      context: Context) -> None:
         if overload.name():
-            self.fail('No overload variant of {} matches argument types'
-                      .format(overload.name()), context)
+            self.fail('No overload variant of {} matches argument types {}'
+                      .format(overload.name(), arg_types), context)
         else:
-            self.fail('No overload variant matches argument types', context)
+            self.fail('No overload variant matches argument types {}'.format(arg_types), context)
 
     def function_variants_overlap(self, n1: int, n2: int,
                                   context: Context) -> None:

--- a/mypy/test/data/check-abstract.test
+++ b/mypy/test/data/check-abstract.test
@@ -411,7 +411,7 @@ B().f(1)
 a = B() # type: A
 a.f(1)
 a.f('')
-a.f(B()) # E: No overload variant of "f" of "A" matches argument types
+a.f(B()) # E: No overload variant of "f" of "A" matches argument types [__main__.B]
 
 [case testOverloadedAbstractMethodWithAlternativeDecoratorOrder]
 from abc import abstractmethod, ABCMeta
@@ -436,7 +436,7 @@ B().f(1)
 a = B() # type: A
 a.f(1)
 a.f('')
-a.f(B()) # E: No overload variant of "f" of "A" matches argument types
+a.f(B()) # E: No overload variant of "f" of "A" matches argument types [__main__.B]
 
 [case testOverloadedAbstractMethodVariantMissingDecorator1]
 from abc import abstractmethod, ABCMeta

--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -324,7 +324,7 @@ class A:
 a = None # type: A
 a.g()
 a.g(B())
-a.g(a) # E: No overload variant matches argument types
+a.g(a) # E: No overload variant matches argument types [__main__.A]
 
 [case testMethodAsDataAttributeInferredFromDynamicallyTypedMethod]
 

--- a/mypy/test/data/check-overloading.test
+++ b/mypy/test/data/check-overloading.test
@@ -33,7 +33,7 @@ main: note: In member "f" of class "A":
 
 [case testCallToOverloadedFunction]
 from typing import overload
-f(C()) # E: No overload variant of "f" matches argument types
+f(C()) # E: No overload variant of "f" matches argument types [__main__.C]
 f(A())
 f(B())
 
@@ -63,7 +63,7 @@ class B: pass
 
 [case testCallToOverloadedMethod]
 from typing import overload
-A().f(C()) # E: No overload variant of "f" of "A" matches argument types
+A().f(C()) # E: No overload variant of "f" of "A" matches argument types [__main__.C]
 A().f(A())
 A().f(B())
 
@@ -102,11 +102,11 @@ from typing import overload
 a, b = None, None # type: (A, B)
 a = f(a)
 b = f(a) # E: Incompatible types in assignment (expression has type "A", variable has type "B")
-f(b)     # E: No overload variant of "f" matches argument types
+f(b)     # E: No overload variant of "f" matches argument types [__main__.B]
 b = f(b, a)
 a = f(b, a) # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-f(a, a)     # E: No overload variant of "f" matches argument types
-f(b, b)     # E: No overload variant of "f" matches argument types
+f(a, a)     # E: No overload variant of "f" matches argument types [__main__.A, __main__.A]
+f(b, b)     # E: No overload variant of "f" matches argument types [__main__.B, __main__.B]
 
 @overload
 def f(x: 'A') -> 'A': pass
@@ -137,7 +137,7 @@ from typing import overload
 a, b = None, None # type: (A, B)
 a = A(a)
 a = A(b)
-a = A(object()) # E: No overload variant of "A" matches argument types
+a = A(object()) # E: No overload variant of "A" matches argument types [builtins.object]
 
 class A:
   @overload
@@ -244,7 +244,7 @@ f(A(), A, A)
 f(B())
 f(B(), B)
 f(B(), B, B)
-f(object()) # E: No overload variant of "f" matches argument types
+f(object()) # E: No overload variant of "f" matches argument types [builtins.object]
 class A: pass
 class B: pass
 [builtins fixtures/list.py]
@@ -257,8 +257,8 @@ def f(x: 'A', *more: 'B') -> 'A': pass
 def f(x: 'B', *more: 'A') -> 'A': pass
 f(A(), B())
 f(A(), B(), B())
-f(A(), A(), B()) # E: No overload variant of "f" matches argument types
-f(A(), B(), A()) # E: No overload variant of "f" matches argument types
+f(A(), A(), B()) # E: No overload variant of "f" matches argument types [__main__.A, __main__.A, __main__.B]
+f(A(), B(), A()) # E: No overload variant of "f" matches argument types [__main__.A, __main__.B, __main__.A]
 class A: pass
 class B: pass
 [builtins fixtures/list.py]
@@ -400,7 +400,7 @@ A() < B()
 B() < A()
 B() < B()
 A() < object() # E: Unsupported operand types for < ("A" and "object")
-B() < object() # E: No overload variant of "__lt__" of "B" matches argument types
+B() < object() # E: No overload variant of "__lt__" of "B" matches argument types [builtins.object]
 
 [case testOverloadedForwardMethodAndCallingReverseMethod]
 from typing import overload
@@ -414,7 +414,7 @@ class B:
 A() + A()
 A() + 1
 A() + B()
-A() + '' # E: No overload variant of "__add__" of "A" matches argument types
+A() + '' # E: No overload variant of "__add__" of "A" matches argument types [builtins.str]
 
 [case testOverrideOverloadedMethodWithMoreGeneralArgumentTypes]
 from typing import overload, builtinclass
@@ -495,7 +495,7 @@ def f(x: str) -> None: pass
 f(1.1)
 f('')
 f(1)
-f(()) # E: No overload variant of "f" matches argument types
+f(()) # E: No overload variant of "f" matches argument types [Tuple[]]
 [builtins fixtures/primitives.py]
 [out]
 

--- a/mypy/test/data/python2eval.test
+++ b/mypy/test/data/python2eval.test
@@ -184,7 +184,7 @@ f.write(u'foo')
 f.write('bar')
 f.close()
 [out]
-_program.py:3: error: No overload variant of "write" of "BinaryIO" matches argument types
+_program.py:3: error: No overload variant of "write" of "BinaryIO" matches argument types [builtins.unicode]
 
 [case testPrintFunctionWithFileArg_python2]
 from __future__ import print_function
@@ -372,4 +372,4 @@ def f(x: unicode) -> int: pass
 @overload
 def f(x: bytearray) -> int: pass
 [out]
-_program.py:2: error: No overload variant of "f" matches argument types
+_program.py:2: error: No overload variant of "f" matches argument types [builtins.int]


### PR DESCRIPTION
This will make debugging type annotations easier.