### PR TITLE
Fix when yield from was made of an AnyType

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1727,7 +1727,9 @@ class TypeChecker(NodeVisitor[Type]):
         # result = self.expr_checker.visit_yield_from_expr(e)
         result = self.accept(e.expr)
         result_instance = cast(Instance, result)
-        if result_instance.type.fullname() == "asyncio.futures.Future":
+        if isinstance(result_instance, AnyType):
+            result = AnyType()
+        elif result_instance.type.fullname() == "asyncio.futures.Future":
             self.function_stack[-1].is_coroutine = True  # Set the function as coroutine
             result = result_instance.args[0]  # Set the return type as the type inside
         elif is_subtype(result, self.named_type('typing.Iterable')):


### PR DESCRIPTION
As reported in #868 and the generic example that @nierob reported in #836

Now don't crash in:

```
import asyncio

@asyncio.coroutine
def example_coro():
    q = asyncio.Queue()
    msg = yield from q.get()

if __name__ == '__main__':
    loop = asyncio.get_event_loop()
    loop.run_until_complete(example_coro())
```

But that example is because don't infer asyncio.Queue type properly as
is appointed in #836, and q is AnyType (instead of asyncio.Queue)

and

```
import asyncio
import typing

@asyncio.coroutine
def foo(a):
   b = yield from a
   return b
```