### PR TITLE
Disambiguate incompatible arguments if necessary.

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -416,8 +416,14 @@ class MessageBuilder:
                 expected_type = callee.arg_types[m - 1]
             except IndexError:  # Varargs callees
                 expected_type = callee.arg_types[-1]
+            arg_type_str = self.format(arg_type)
+            expected_type_str = self.format(expected_type)
+            # If type names turn out ambiguous, attempt to disambiguate.
+            if arg_type_str == expected_type_str:
+                arg_type_str = self.format(arg_type, verbose=True)
+                expected_type_str = self.format(expected_type, verbose=True)
             msg = 'Argument {} {}has incompatible type {}; expected {}'.format(
-                n, target, self.format(arg_type), self.format(expected_type))
+                n, target, arg_type_str, expected_type_str)
         self.fail(msg, context)
 
     def invalid_index_type(self, index_type: Type, base_str: str,


### PR DESCRIPTION
A typo where a class is accidentally passed in place of an instance currently produces the confusing error message `incompatible type: Foo; expected: Foo`. This will fall back on verbose formatting in such cases.

Thanks for making mypy!