### PR TITLE
Add support for tuple slices.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1018,11 +1018,23 @@ class ExpressionChecker:
         end = len(left_type.items)
         stride = 1
         if slic.begin_index:
-            begin = slic.begin_index.value
+            if isinstance(slic.begin_index, IntExpr):
+                begin = slic.begin_index.value
+            else:
+                self.chk.fail(messages.TUPLE_SLICE_MUST_BE_AN_INT_LITERAL, slic.begin_index)
+                return AnyType()
         if slic.end_index:
-            end = slic.end_index.value
+            if isinstance(slic.end_index, IntExpr):
+                end = slic.end_index.value
+            else:
+                self.chk.fail(messages.TUPLE_SLICE_MUST_BE_AN_INT_LITERAL, slic.end_index)
+                return AnyType()
         if slic.stride:
-            stride = slic.stride.value
+            if isinstance(slic.stride, IntExpr):
+                stride = slic.stride.value
+            else:
+                self.chk.fail(messages.TUPLE_SLICE_MUST_BE_AN_INT_LITERAL, slic.stride)
+                return AnyType()
 
         return TupleType(left_type.items[begin:end:stride], left_type.fallback,
                     left_type.line, left_type.implicit)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -41,7 +41,8 @@ INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION = 'Incompatible types in string interpol
 INIT_MUST_HAVE_NONE_RETURN_TYPE = 'The return type of "__init__" must be None'
 GETTER_TYPE_INCOMPATIBLE_WITH_SETTER = \
     'Type of getter incompatible with setter'
-TUPLE_INDEX_MUST_BE_AN_INT_LITERAL = 'Tuple index must an integer literal'
+TUPLE_INDEX_MUST_BE_AN_INT_LITERAL = 'Tuple index must be an integer literal'
+TUPLE_SLICE_MUST_BE_AN_INT_LITERAL = 'Tuple slice must be an integer literal'
 TUPLE_INDEX_OUT_OF_RANGE = 'Tuple index out of range'
 TYPE_CONSTANT_EXPECTED = 'Type "Constant" or initializer expected'
 INCOMPATIBLE_PAIR_ITEM_TYPE = 'Incompatible Pair item type'

--- a/mypy/test/data/check-tuples.test
+++ b/mypy/test/data/check-tuples.test
@@ -152,7 +152,10 @@ def f() -> None: pass
 from typing import Tuple
 t1 = None # type: Tuple[A, B]
 t2 = None # type: Tuple[A]
+t3 = None # type: Tuple[A, B, C, D, E]
 a, b = None, None # type: (A, B)
+x = None # type: Tuple[A, B, C]
+y = None # type: Tuple[A, C, E]
 n = 0
 
 a = t1[1] # E: Incompatible types in assignment (expression has type "B", variable has type "A")
@@ -166,9 +169,14 @@ b = t1[(0)] # E: Incompatible types in assignment (expression has type "A", vari
 a = t1[0]
 b = t1[1]
 a = t1[(0)]
+x = t3[0:3] # type (A, B, C)
+y = t3[0:5:2] # type (A, C, E)
 
 class A: pass
 class B: pass
+class C: pass
+class D: pass
+class E: pass
 [builtins fixtures/tuple.py]
 
 [case testIndexingTuplesWithNegativeIntegers]

--- a/mypy/test/data/check-tuples.test
+++ b/mypy/test/data/check-tuples.test
@@ -163,7 +163,8 @@ b = t1[0] # E: Incompatible types in assignment (expression has type "A", variab
 t1[2]     # E: Tuple index out of range
 t1[3]     # E: Tuple index out of range
 t2[1]     # E: Tuple index out of range
-t1[n]     # E: Tuple index must an integer literal
+t1[n]     # E: Tuple index must be an integer literal
+t3[n:]    # E: Tuple slice must be an integer literal
 b = t1[(0)] # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 
 a = t1[0]


### PR DESCRIPTION
Apparently python happily accepts any slice, even if its
out of range (and just gives an empty tuple). Personally,
I find that behavior weird, but I opted to not check any
ranges because python itself doesn't care.

#886