### PR TITLE
Enable IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ install:
   - python setup.py install
 
 script: bash travis.sh
+
+notifications:
+  irc:
+    channels:
+      - "chat.freenode.net##mypy"
+    use_notice: true


### PR DESCRIPTION
This commit has been sitting at the head of my other PRs, but it's really separate.

I've registered `##mypy` as an unofficial channel and have already sent my own travis reports there. 

There are channel-sitters in `#mypy`, which is currently unregistered - if you want the channel to be *official*, you'll have to talk to staff in `#freenode` to take it over.