### PR TITLE
add git (submodule) integrity check

### DIFF
--- a/mypy/git.py
+++ b/mypy/git.py
@@ -1,0 +1,109 @@
+"""Utilities for verifying git integrity."""
+
+# Used also from setup.py, so don't pull in anything additional here (like mypy or typing):
+import os
+import pipes
+import subprocess
+import sys
+
+
+def is_git_repo(dir: str) -> bool:
+    """Is the passed directory version controlled with git?"""
+    return os.path.exists(os.path.join(dir, ".git"))
+
+
+def have_git() -> bool:
+    """Can we run the git executable?"""
+    try:
+        subprocess.check_output(["git", "config", "-l"])
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def run_in_dir(dir, command) -> bytes:
+    """Convenience function: Run a command in a directory."""
+    return subprocess.check_output("cd " + pipes.quote(dir) + "; " + command,
+                                   shell=True)
+
+
+def get_submodules(dir: str):
+    """Return a list of all git top-level submodules in a given directory."""
+    # It would be nicer to do
+    # "git submodule foreach 'echo MODULE $name $path $sha1 $toplevel'"
+    # but that wouldn't work on Windows.
+    output = run_in_dir(dir, "git submodule status")
+    for line in output.splitlines():
+        status = line[0]
+        sha5, name, *_ = line[1:].split(b" ")
+        yield (status, sha5, name.decode(sys.getfilesystemencoding()))
+
+
+def git_revision(dir: str) -> bytes:
+    """Get the SHA-1 of the HEAD of a git repository."""
+    return run_in_dir(dir, "git rev-parse HEAD").strip()
+
+
+def is_dirty(dir: str) -> bool:
+    """Check whether a git repository has uncommitted changes."""
+    return run_in_dir(dir, "git status -uno --porcelain").strip() != b""
+
+
+def has_extra_files(dir: str) -> bool:
+    """Check whether a git repository has untracked files."""
+    return run_in_dir(dir, "git clean --dry-run -d").strip() != b""
+
+
+def warn_no_git_executable() -> None:
+    print("Warning: Couldn't check git integrity. "
+          "git executable not in path.", file=sys.stderr)
+
+
+def warn_dirty(dir) -> None:
+    print("Warning: git module '{}' has uncommitted changes.".format(dir),
+          file=sys.stderr)
+
+
+def warn_extra_files(dir) -> None:
+    print("Warning: git module '{}' has untracked files.".format(dir),
+          file=sys.stderr)
+
+
+def error_submodule_not_initialized(name: str, dir: str) -> None:
+    print("Submodule '{}' not initialized.".format(name), file=sys.stderr)
+    print("Please run:", file=sys.stderr)
+    print("  cd {}".format(pipes.quote(dir)), file=sys.stderr)
+    print("  git submodule init {}".format(name), file=sys.stderr)
+
+
+def error_submodule_not_updated(name: str, dir: str) -> None:
+    print("Submodule '{}' not updated.".format(name), file=sys.stderr)
+    print("Please run:", file=sys.stderr)
+    print("  cd {}".format(pipes.quote(dir)), file=sys.stderr)
+    print("  git submodule update {}".format(name), file=sys.stderr)
+
+
+def verify_git_integrity_or_abort(datadir: str) -> None:
+    """Verify the (submodule) integrity of a git repository.
+
+    Potentially output warnings/errors (to stderr), and exit with status 1
+    if we detected a severe problem.
+    """
+
+    if not is_git_repo(datadir):
+        return
+    if not have_git():
+        warn_no_git_executable()
+        return
+    for _, revision, submodule in get_submodules(datadir):
+        submodule_path = os.path.join(datadir, submodule)
+        if not is_git_repo(submodule_path):
+            error_submodule_not_initialized(submodule, datadir)
+            sys.exit(1)
+        elif revision != git_revision(submodule_path):
+            error_submodule_not_updated(submodule, datadir)
+            sys.exit(1)
+        elif is_dirty(submodule_path):
+            warn_dirty(submodule)
+        elif has_extra_files(submodule_path):
+            warn_extra_files(submodule)

--- a/mypy/git.py
+++ b/mypy/git.py
@@ -81,19 +81,27 @@ def warn_extra_files(dir) -> None:
     print("and add & commit your new files.", file=sys.stderr)
 
 
+def chdir_prefix(dir) -> str:
+    """Return the command to change to the target directory, plus '&&'."""
+    if os.path.relpath(dir) != ".":
+        return "cd " + pipes.quote(dir) + " && "
+    else:
+        return ""
+
+
 def error_submodule_not_initialized(name: str, dir: str) -> None:
     print("Submodule '{}' not initialized.".format(name), file=sys.stderr)
     print("Please run:", file=sys.stderr)
-    print("  cd {}".format(pipes.quote(dir)), file=sys.stderr)
-    print("  git submodule init {}".format(name), file=sys.stderr)
+    print("  {}git submodule update --init {}".format(
+        chdir_prefix(dir), name), file=sys.stderr)
 
 
 def error_submodule_not_updated(name: str, dir: str) -> None:
     print("Submodule '{}' not updated.".format(name), file=sys.stderr)
     print("Please run:", file=sys.stderr)
-    print("  cd {}".format(pipes.quote(dir)), file=sys.stderr)
-    print("  git submodule update {}".format(name), file=sys.stderr)
-    print("(If you got this message because you updated {}".format(name), file=sys.stderr)
+    print("  {}git submodule update {}".format(
+        chdir_prefix(dir), name), file=sys.stderr)
+    print("(If you got this message because you updated {} yourself".format(name), file=sys.stderr)
     print(" then run \"git add {}\" to silence this check)".format(name), file=sys.stderr)
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -123,7 +123,7 @@ def process_options(args: List[str]) -> Tuple[str, str, str, Options]:
             args = args[2:]
         elif args[0] == '-f' or args[0] == '--dirty-stubs':
             options.dirty_stubs = True
-            args = args[2:]
+            args = args[1:]
         elif args[0] == '-m' and args[1:]:
             options.build_flags.append(build.MODULE)
             return None, args[1], None, options

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Tuple
 
 from mypy import build
 from mypy import defaults
+from mypy import git
 from mypy.errors import CompileError
 
 from mypy.version import __version__
@@ -26,6 +27,7 @@ class Options:
         self.custom_typing_module = None  # type: str
         self.report_dirs = {}  # type: Dict[str, str]
         self.python_path = False
+        self.dirty_stubs = False
 
 
 def main(script_path: str) -> None:
@@ -39,6 +41,8 @@ def main(script_path: str) -> None:
     else:
         bin_dir = None
     path, module, program_text, options = process_options(sys.argv[1:])
+    if not options.dirty_stubs:
+        git.verify_git_integrity_or_abort(build.default_data_dir(bin_dir))
     try:
         if options.target == build.TYPE_CHECK:
             type_check_only(path, module, program_text, bin_dir, options)
@@ -116,6 +120,9 @@ def process_options(args: List[str]) -> Tuple[str, str, str, Options]:
                 fail("Found non-digit in python version: {}".format(
                     args[1]))
             options.pyversion = (int(version_components[0]), int(version_components[1]))
+            args = args[2:]
+        elif args[0] == '-f' or args[0] == '--dirty-stubs':
+            options.dirty_stubs = True
             args = args[2:]
         elif args[0] == '-m' and args[1:]:
             options.build_flags.append(build.MODULE)

--- a/runtests.py
+++ b/runtests.py
@@ -26,6 +26,7 @@ if True:
 from typing import Dict, List, Optional, Set
 
 from mypy.waiter import Waiter, LazySubprocess
+from mypy import git
 
 import itertools
 import os
@@ -293,6 +294,7 @@ def main() -> None:
     blacklist = []  # type: List[str]
     arglist = []  # type: List[str]
     list_only = False
+    dirty_stubs = False
 
     allow_opts = True
     curlist = whitelist
@@ -312,6 +314,8 @@ def main() -> None:
                 curlist = arglist
             elif a == '-l' or a == '--list':
                 list_only = True
+            elif a == '-f' or a == '--dirty-stubs':
+                dirty_stubs = True
             elif a == '-h' or a == '--help':
                 usage(0)
             else:
@@ -329,6 +333,10 @@ def main() -> None:
 
     driver = Driver(whitelist=whitelist, blacklist=blacklist, arglist=arglist,
             verbosity=verbosity, xfail=[])
+
+    if not dirty_stubs:
+        git.verify_git_integrity_or_abort(driver.cwd)
+
     driver.prepend_path('PATH', [join(driver.cwd, 'scripts')])
     driver.prepend_path('MYPYPATH', [driver.cwd])
     driver.prepend_path('PYTHONPATH', [driver.cwd])

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def find_data_files(base, globs):
 
 data_files = []
 
-data_files += find_data_files('typeshed', ['*.py', '*.pyi'])
+data_files += find_data_files('stubs', ['*.py', '*.pyi'])
 
 data_files += find_data_files('xml', ['*.xsd', '*.xslt', '*.css'])
 

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,13 @@ import sys
 
 from distutils.core import setup
 from mypy.version import __version__
+from mypy import git
 
 if sys.version_info < (3, 2, 0):
     sys.stderr.write("ERROR: You need Python 3.2 or later to use mypy.\n")
     exit(1)
+
+git.verify_git_integrity_or_abort(".")
 
 version = __version__
 description = 'Optional static typing for Python'

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def find_data_files(base, globs):
 
 data_files = []
 
-data_files += find_data_files('stubs', ['*.py', '*.pyi'])
+data_files += find_data_files('typeshed', ['*.py', '*.pyi'])
 
 data_files += find_data_files('xml', ['*.xsd', '*.xslt', '*.css'])
 


### PR DESCRIPTION
If mypy is a git repository and has submodules, check that the submodules are initialized and up-to-date (and abort if not) in runtests.py, scripts/mypy, setup.py. Also check if they're dirty, and output a warning if so.
New option --dirty-stubs for runtests.py + scripts/mypy, for bypassing said checks.

This is a standalone PR. It doesn't depend on #884, or the other way around.
So you can merge them in any order.