### PR TITLE
Report where a mismatching definition comes from

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -53,12 +53,9 @@ def apply_generic_arguments(callable: CallableType, types: List[Type],
     # The callable may retain some type vars if only some were applied.
     remaining_tvars = [tv for tv in tvars if tv.id not in id_to_type]
 
-    return CallableType(arg_types,
-                    callable.arg_kinds,
-                    callable.arg_names,
-                    expand_type(callable.ret_type, id_to_type),
-                    callable.fallback,
-                    callable.name,
-                    remaining_tvars,
-                    callable.bound_vars + bound_vars,
-                    callable.line)
+    return callable.copy_modified(
+        arg_types=arg_types,
+        ret_type=expand_type(callable.ret_type, id_to_type),
+        variables=remaining_tvars,
+        bound_vars=callable.bound_vars + bound_vars,
+    )

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -347,7 +347,7 @@ class TypeChecker(NodeVisitor[Type]):
         self.errors = errors
         self.modules = modules
         self.pyversion = pyversion
-        self.msg = MessageBuilder(errors)
+        self.msg = MessageBuilder(errors, modules)
         self.type_map = {}
         self.binder = ConditionalTypeBinder()
         self.binder.push_frame()

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1083,8 +1083,8 @@ class ExpressionChecker:
             [None],
             self.chk.named_generic_type(fullname, [tv]),
             self.named_type('builtins.function'),
-            tag,
-            [TypeVarDef('T', -1, None, self.chk.object_type())])
+            name=tag,
+            variables=[TypeVarDef('T', -1, None, self.chk.object_type())])
         return self.check_call(constructor,
                                items,
                                [nodes.ARG_POS] * len(items), context)[0]
@@ -1124,9 +1124,9 @@ class ExpressionChecker:
             [None],
             self.chk.named_generic_type('builtins.dict', [tv1, tv2]),
             self.named_type('builtins.function'),
-            '<list>',
-            [TypeVarDef('KT', -1, None, self.chk.object_type()),
-             TypeVarDef('VT', -2, None, self.chk.object_type())])
+            name='<list>',
+            variables=[TypeVarDef('KT', -1, None, self.chk.object_type()),
+                       TypeVarDef('VT', -2, None, self.chk.object_type())])
         # Synthesize function arguments.
         args = []  # type: List[Node]
         for key, value in e.items:
@@ -1238,8 +1238,8 @@ class ExpressionChecker:
             [None],
             self.chk.named_generic_type(type_name, [tv]),
             self.chk.named_type('builtins.function'),
-            id_for_messages,
-            [TypeVarDef('T', -1, None, self.chk.object_type())])
+            name=id_for_messages,
+            variables=[TypeVarDef('T', -1, None, self.chk.object_type())])
         return self.check_call(constructor,
                                [gen.left_expr], [nodes.ARG_POS], gen)[0]
 
@@ -1257,9 +1257,9 @@ class ExpressionChecker:
             [None, None],
             self.chk.named_generic_type('builtins.dict', [key_tv, value_tv]),
             self.chk.named_type('builtins.function'),
-            '<dictionary-comprehension>',
-            [TypeVarDef('KT', -1, None, self.chk.object_type()),
-             TypeVarDef('VT', -2, None, self.chk.object_type())])
+            name='<dictionary-comprehension>',
+            variables=[TypeVarDef('KT', -1, None, self.chk.object_type()),
+                       TypeVarDef('VT', -2, None, self.chk.object_type())])
         return self.check_call(constructor,
                                [e.key, e.value], [nodes.ARG_POS, nodes.ARG_POS], e)[0]
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1467,15 +1467,7 @@ def is_duplicate_mapping(mapping: List[int], actual_kinds: List[int]) -> bool:
 
 def replace_callable_return_type(c: CallableType, new_ret_type: Type) -> CallableType:
     """Return a copy of a callable type with a different return type."""
-    return CallableType(c.arg_types,
-                    c.arg_kinds,
-                    c.arg_names,
-                    new_ret_type,
-                    c.fallback,
-                    c.name,
-                    c.variables,
-                    c.bound_vars,
-                    c.line)
+    return c.copy_modified(ret_type=new_ret_type)
 
 
 class ArgInferSecondPassQuery(types.TypeQuery):

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -250,15 +250,8 @@ def add_class_tvars(t: Type, info: TypeInfo, is_classmethod: bool,
             arg_types = arg_types[1:]
             arg_kinds = arg_kinds[1:]
             arg_names = arg_names[1:]
-        return CallableType(arg_types,
-                        arg_kinds,
-                        arg_names,
-                        t.ret_type,
-                        t.fallback,
-                        t.name,
-                        vars + t.variables,
-                        t.bound_vars,
-                        t.line)
+        return t.copy_modified(arg_types=arg_types, arg_kinds=arg_kinds, arg_names=arg_names,
+                               variables=vars + t.variables)
     elif isinstance(t, Overloaded):
         return Overloaded([cast(CallableType, add_class_tvars(i, info, is_classmethod,
                                                               builtin_type))
@@ -303,13 +296,9 @@ def class_callable(init_type: CallableType, info: TypeInfo, type_type: Instance)
     initvars = init_type.variables
     variables.extend(initvars)
 
-    c = CallableType(init_type.arg_types,
-                 init_type.arg_kinds,
-                 init_type.arg_names,
-                 self_type(info),
-                 type_type,
-                 None,
-                 variables).with_name('"{}"'.format(info.name()))
+    callable_type = init_type.copy_modified(
+        ret_type=self_type(info), fallback=type_type, name=None, variables=variables)
+    c = callable_type.with_name('"{}"'.format(info.name()))
     return convert_class_tvars_to_func_tvars(c, len(initvars))
 
 

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -76,16 +76,9 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
             return repl
 
     def visit_callable_type(self, t: CallableType) -> Type:
-        return CallableType(self.expand_types(t.arg_types),
-                            t.arg_kinds,
-                            t.arg_names,
-                            t.ret_type.accept(self),
-                            t.fallback,
-                            t.name,
-                            t.variables,
-                            self.expand_bound_vars(t.bound_vars),
-                            t.line,
-                            t.is_ellipsis_args)
+        return t.copy_modified(arg_types=self.expand_types(t.arg_types),
+                               ret_type=t.ret_type.accept(self),
+                               bound_vars=self.expand_bound_vars(t.bound_vars))
 
     def visit_overloaded(self, t: Overloaded) -> Type:
         items = []  # type: List[CallableType]
@@ -116,14 +109,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
 def update_callable_implicit_bounds(
         t: CallableType, arg_types: List[Tuple[int, Type]]) -> CallableType:
     # FIX what if there are existing bounds?
-    return CallableType(t.arg_types,
-                    t.arg_kinds,
-                    t.arg_names,
-                    t.ret_type,
-                    t.fallback,
-                    t.name,
-                    t.variables,
-                    arg_types, t.line)
+    return t.copy_modified(bound_vars=arg_types)
 
 
 def expand_caller_var_args(arg_types: List[Type],

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -285,14 +285,10 @@ def combine_similar_callables(t: CallableType, s: CallableType) -> CallableType:
         fallback = t.fallback
     else:
         fallback = s.fallback
-    return CallableType(arg_types,
-                    t.arg_kinds,
-                    t.arg_names,
-                    join_types(t.ret_type, s.ret_type),
-                    fallback,
-                    None,
-                    t.variables)
-    return s
+    return t.copy_modified(arg_types=arg_types,
+                           ret_type=join_types(t.ret_type, s.ret_type),
+                           fallback=fallback,
+                           name=None)
 
 
 def object_from_instance(instance: Instance) -> Instance:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1732,14 +1732,9 @@ def method_type(sig: 'mypy.types.FunctionLike') -> 'mypy.types.FunctionLike':
 
 
 def method_callable(c: 'mypy.types.CallableType') -> 'mypy.types.CallableType':
-    return mypy.types.CallableType(c.arg_types[1:],
-                               c.arg_kinds[1:],
-                               c.arg_names[1:],
-                               c.ret_type,
-                               c.fallback,
-                               c.name,
-                               c.variables,
-                               c.bound_vars)
+    return c.copy_modified(arg_types=c.arg_types[1:],
+                           arg_kinds=c.arg_kinds[1:],
+                           arg_names=c.arg_names[1:])
 
 
 class MroError(Exception):

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -442,6 +442,8 @@ class Parser:
 
             node = FuncDef(name, arg_vars, kinds, init, body, typ)
             node.set_line(def_tok)
+            if typ is not None:
+                typ.definition = node
             return node
         finally:
             self.errors.pop_function()

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -657,8 +657,8 @@ class Parser:
             ret_type = AnyType()
         arg_kinds = [arg.kind for arg in args]
         arg_names = [arg.variable.name() for arg in args]
-        return CallableType(arg_types, arg_kinds, arg_names, ret_type, None, None,
-                        None, [], line)
+        return CallableType(arg_types, arg_kinds, arg_names, ret_type, None, name=None,
+                        variables=None, bound_vars=[], line=line)
 
     # Parsing statements
 

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -294,6 +294,7 @@ def expand_errors(input, output, fnam):
     """
 
     for i in range(len(input)):
-        m = re.search('# E: (.*)$', input[i])
+        m = re.search('# ([EN]): (.*)$', input[i])
         if m:
-            output.append('{}:{}: error: {}'.format(fnam, i + 1, m.group(1)))
+            severity = 'error' if m.group(1) == 'E' else 'note'
+            output.append('{}:{}: {}: {}'.format(fnam, i + 1, severity, m.group(2)))

--- a/mypy/test/data/check-kwargs.test
+++ b/mypy/test/data/check-kwargs.test
@@ -77,7 +77,7 @@ class B: pass
 
 [case testInvalidKeywordArgument]
 import typing
-def f(a: 'A') -> None: pass
+def f(a: 'A') -> None: pass # N: "f" defined here
 f(b=object()) # E: Unexpected keyword argument "b" for "f"
 class A: pass
 
@@ -236,7 +236,7 @@ class A: pass
 
 [case testKeywordArgumentAndCommentSignature]
 import typing
-def f(x): # type: (int) -> str
+def f(x): # type: (int) -> str # N: "f" defined here
     pass
 f(x='') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 f(x=0)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -84,13 +84,13 @@ class TypesSuite(Suite):
 
     def test_generic_function_type(self):
         c = CallableType([self.x, self.y], [ARG_POS, ARG_POS], [None, None],
-                     self.y, self.function, None,
-                     [TypeVarDef('X', -1, None, self.fx.o)])
+                     self.y, self.function, name=None,
+                     variables=[TypeVarDef('X', -1, None, self.fx.o)])
         assert_equal(str(c), 'def [X] (X?, Y?) -> Y?')
 
         v = [TypeVarDef('Y', -1, None, self.fx.o),
              TypeVarDef('X', -2, None, self.fx.o)]
-        c2 = CallableType([], [], [], Void(None), self.function, None, v)
+        c2 = CallableType([], [], [], Void(None), self.function, name=None, variables=v)
         assert_equal(str(c2), 'def [Y, X] ()')
 
 
@@ -268,8 +268,8 @@ class TypeOpsSuite(Suite):
                             [None] * (len(a) - 1),
                             a[-1],
                             self.fx.function,
-                            None,
-                            tv)
+                            name=None,
+                            variables=tv)
 
 
 class JoinSuite(Suite):

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -160,16 +160,11 @@ class TypeAnalyser(TypeVisitor[Type]):
         raise RuntimeError('TypeVarType is already analyzed')
 
     def visit_callable_type(self, t: CallableType) -> Type:
-        res = CallableType(self.anal_array(t.arg_types),
-                       t.arg_kinds,
-                       t.arg_names,
-                       t.ret_type.accept(self),
-                       self.builtin_type('builtins.function'),
-                       t.name,
-                       self.anal_var_defs(t.variables),
-                       self.anal_bound_vars(t.bound_vars), t.line)
-
-        return res
+        return t.copy_modified(arg_types=self.anal_array(t.arg_types),
+                               ret_type=t.ret_type.accept(self),
+                               fallback=self.builtin_type('builtins.function'),
+                               variables=self.anal_var_defs(t.variables),
+                               bound_vars=self.anal_bound_vars(t.bound_vars))
 
     def visit_tuple_type(self, t: TupleType) -> Type:
         if t.implicit:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Any, TypeVar, List, Tuple, cast, Generic, Set
 
 import mypy.nodes
-from mypy.nodes import INVARIANT
+from mypy.nodes import INVARIANT, SymbolNode
 
 
 T = TypeVar('T')
@@ -237,6 +237,7 @@ class CallableType(FunctionLike):
     is_var_arg = False              # Is it a varargs function?
     ret_type = None  # type:Type    # Return value type
     name = ''                       # Name (may be None; for error messages)
+    definition = None  # type: SymbolNode # For error messages.  May be None.
     # Type variables for a generic function
     variables = None  # type: List[TypeVarDef]
 
@@ -264,6 +265,7 @@ class CallableType(FunctionLike):
                  ret_type: Type,
                  fallback: Instance,
                  name: str = None,
+                 definition: SymbolNode = None,
                  variables: List[TypeVarDef] = None,
                  bound_vars: List[Tuple[int, Type]] = None,
                  line: int = -1,
@@ -281,6 +283,7 @@ class CallableType(FunctionLike):
         self.fallback = fallback
         assert not name or '<bound method' not in name
         self.name = name
+        self.definition = definition
         self.variables = variables
         self.bound_vars = bound_vars
         self.is_ellipsis_args = is_ellipsis_args
@@ -293,6 +296,7 @@ class CallableType(FunctionLike):
                       ret_type: Type = _dummy,
                       fallback: Instance = _dummy,
                       name: str = _dummy,
+                      definition: SymbolNode = _dummy,
                       variables: List[TypeVarDef] = _dummy,
                       bound_vars: List[Tuple[int, Type]] = _dummy,
                       line: int = _dummy,
@@ -304,6 +308,7 @@ class CallableType(FunctionLike):
             ret_type=ret_type if ret_type is not _dummy else self.ret_type,
             fallback=fallback if fallback is not _dummy else self.fallback,
             name=name if name is not _dummy else self.name,
+            definition=definition if definition is not _dummy else self.definition,
             variables=variables if variables is not _dummy else self.variables,
             bound_vars=bound_vars if bound_vars is not _dummy else self.bound_vars,
             line=line if line is not _dummy else self.line,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -224,6 +224,9 @@ class FunctionLike(Type):
     fallback = None  # type: Instance
 
 
+_dummy = object()  # type: Any
+
+
 class CallableType(FunctionLike):
     """Type of a non-overloaded callable object (function)."""
 
@@ -283,6 +286,31 @@ class CallableType(FunctionLike):
         self.is_ellipsis_args = is_ellipsis_args
         super().__init__(line)
 
+    def copy_modified(self,
+                      arg_types: List[Type] = _dummy,
+                      arg_kinds: List[int] = _dummy,
+                      arg_names: List[str] = _dummy,
+                      ret_type: Type = _dummy,
+                      fallback: Instance = _dummy,
+                      name: str = _dummy,
+                      variables: List[TypeVarDef] = _dummy,
+                      bound_vars: List[Tuple[int, Type]] = _dummy,
+                      line: int = _dummy,
+                      is_ellipsis_args: bool = _dummy) -> 'CallableType':
+        return CallableType(
+            arg_types=arg_types if arg_types is not _dummy else self.arg_types,
+            arg_kinds=arg_kinds if arg_kinds is not _dummy else self.arg_kinds,
+            arg_names=arg_names if arg_names is not _dummy else self.arg_names,
+            ret_type=ret_type if ret_type is not _dummy else self.ret_type,
+            fallback=fallback if fallback is not _dummy else self.fallback,
+            name=name if name is not _dummy else self.name,
+            variables=variables if variables is not _dummy else self.variables,
+            bound_vars=bound_vars if bound_vars is not _dummy else self.bound_vars,
+            line=line if line is not _dummy else self.line,
+            is_ellipsis_args=(
+                is_ellipsis_args if is_ellipsis_args is not _dummy else self.is_ellipsis_args),
+        )
+
     def is_type_obj(self) -> bool:
         return self.fallback.type.fullname() == 'builtins.type'
 
@@ -301,15 +329,7 @@ class CallableType(FunctionLike):
         ret = self.ret_type
         if isinstance(ret, Void):
             ret = ret.with_source(name)
-        return CallableType(self.arg_types,
-                        self.arg_kinds,
-                        self.arg_names,
-                        ret,
-                        self.fallback,
-                        name,
-                        self.variables,
-                        self.bound_vars,
-                        self.line)
+        return self.copy_modified(ret_type=ret, name=name)
 
     def max_fixed_args(self) -> int:
         n = len(self.arg_types)
@@ -580,16 +600,10 @@ class TypeTranslator(TypeVisitor[Type]):
         return t
 
     def visit_callable_type(self, t: CallableType) -> Type:
-        return CallableType(self.translate_types(t.arg_types),
-                        t.arg_kinds,
-                        t.arg_names,
-                        t.ret_type.accept(self),
-                        t.fallback,
-                        t.name,
-                        self.translate_variables(t.variables),
-                        self.translate_bound_vars(t.bound_vars),
-                        t.line,
-                        t.is_ellipsis_args)
+        return t.copy_modified(arg_types=self.translate_types(t.arg_types),
+                               ret_type=t.ret_type.accept(self),
+                               variables=self.translate_variables(t.variables),
+                               bound_vars=self.translate_bound_vars(t.bound_vars))
 
     def visit_tuple_type(self, t: TupleType) -> Type:
         return TupleType(self.translate_types(t.items),
@@ -842,13 +856,7 @@ def strip_type(typ: Type) -> Type:
     """Make a copy of type without 'debugging info' (function name)."""
 
     if isinstance(typ, CallableType):
-        return CallableType(typ.arg_types,
-                        typ.arg_kinds,
-                        typ.arg_names,
-                        typ.ret_type,
-                        typ.fallback,
-                        None,
-                        typ.variables)
+        return typ.copy_modified(name=None)
     elif isinstance(typ, Overloaded):
         return Overloaded([cast(CallableType, strip_type(item))
                            for item in typ.items()])
@@ -861,15 +869,7 @@ def replace_leading_arg_type(t: CallableType, self_type: Type) -> CallableType:
 
     Assume that the callable is the signature of a method.
     """
-    return CallableType([self_type] + t.arg_types[1:],
-                    t.arg_kinds,
-                    t.arg_names,
-                    t.ret_type,
-                    t.fallback,
-                    t.name,
-                    t.variables,
-                    t.bound_vars,
-                    t.line)
+    return t.copy_modified(arg_types=[self_type] + t.arg_types[1:])
 
 
 def is_named_instance(t: Type, fullname: str) -> bool:


### PR DESCRIPTION
(PR text adapted from commit messages.)

Some type errors could just as well be the result of a
faulty type at a function's definition as of faulty
code at its use.  This is especially likely where the
"definition" is a stub, which may have been written
incompletely and e.g. not describe every keyword argument
the function actually accepts.

When this happens on an unexpected keyword argument, report
the filename and line number where we found the definition,
as a note following the error itself at the function's use.
The message looks something like this:

    some/file.py: note: In function "print_json":
    some/file.py:22: error: Unexpected keyword argument "separators" for "dumps"
    /srv/mypy/stubs/2.7/json.pyi:9: note: "dumps" defined here

Left for future work: adding similar site-of-definition
notes to other error messages where they'd be similarly
useful, and doing so in a nicely abstracted way.

In preparatory commits, make some useful refactors and cleanups
and add some small facilities we need.
