### PR TITLE
Add new node for arguments.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -530,12 +530,13 @@ class TypeChecker(NodeVisitor[Type]):
                     arg_type = self.named_generic_type('builtins.dict',
                                                        [self.str_type(),
                                                         arg_type])
-                item.args[i].type = arg_type
+                item.arguments[i].variable.type = arg_type
 
             # Type check initialization expressions.
-            for j in range(len(item.init)):
-                if item.init[j]:
-                    self.accept(item.init[j])
+            for arg in item.arguments:
+                init = arg.initialization_statement
+                if init:
+                    self.accept(init)
 
             # Clear out the default assignments from the binder
             self.binder.pop_frame()

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1146,7 +1146,7 @@ class ExpressionChecker:
         if not inferred_type:
             # No useful type context.
             ret_type = e.expr().accept(self.chk)
-            if not e.args:
+            if not e.arguments:
                 # Form 'lambda: e'; just use the inferred return type.
                 return CallableType([], [], [], ret_type, self.named_type('builtins.function'))
             else:
@@ -1179,7 +1179,9 @@ class ExpressionChecker:
 
         callable_ctx = cast(CallableType, ctx)
 
-        if callable_ctx.arg_kinds != e.arg_kinds:
+        arg_kinds = [arg.kind for arg in e.arguments]
+
+        if callable_ctx.arg_kinds != arg_kinds:
             # Incompatible context; cannot use it to infer types.
             self.chk.fail(messages.CANNOT_INFER_LAMBDA_TYPE, e)
             return None

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -254,12 +254,49 @@ class OverloadedFuncDef(FuncBase):
         return visitor.visit_overloaded_func_def(self)
 
 
-class FuncItem(FuncBase):
-    args = None  # type: List[Var]  # Argument names
-    arg_kinds = None  # type: List[int]  # Kinds of arguments (ARG_*)
+class Argument(Node):
+    """A single argument in a FuncItem.
+    """
+    def __init__(self, variable: 'Var', type_annotation: 'Optional[mypy.types.Type]',
+            initializer: Optional[Node], kind: int,
+            initialization_statement: Optional['AssignmentStmt'] = None) -> None:
+        self.variable = variable
 
-    # Initialization expessions for fixed args; None if no initializer
-    init = None  # type: List[AssignmentStmt]
+        self.type_annotation = type_annotation
+        self.initializer = initializer
+
+        self.initialization_statement = initialization_statement
+        if not self.initialization_statement:
+            self.initialization_statement = self._initialization_statement()
+
+        self.kind = kind
+
+    def _initialization_statement(self) -> Optional['AssignmentStmt']:
+        """Convert the initializer into an assignment statement.
+        """
+        if not self.initializer:
+            return None
+
+        rvalue = self.initializer
+        lvalue = NameExpr(self.variable.name())
+        assign = AssignmentStmt([lvalue], rvalue)
+        return assign
+
+    def set_line(self, target: Union[Token, int]) -> Node:
+        super().set_line(target)
+
+        if self.initializer:
+            self.initializer.set_line(self.line)
+
+        self.variable.set_line(self.line)
+
+        if self.initialization_statement:
+            self.initialization_statement.set_line(self.line)
+            self.initialization_statement.lvalues[0].set_line(self.line)
+
+
+class FuncItem(FuncBase):
+    arguments = []  # type: List[Argument]
     # Minimum number of arguments
     min_args = 0
     # Maximum number of positional arguments, -1 if no explicit limit (*args not included)
@@ -275,48 +312,28 @@ class FuncItem(FuncBase):
     # Variants of function with type variables with values expanded
     expanded = None  # type: List[FuncItem]
 
-    def __init__(self, args: List['Var'], arg_kinds: List[int],
-                 init: List[Node], body: 'Block',
+    def __init__(self, arguments: List[Argument], body: 'Block',
                  typ: 'mypy.types.FunctionLike' = None) -> None:
-        self.args = args
-        self.arg_kinds = arg_kinds
+        self.arguments = arguments
+        arg_kinds = [arg.kind for arg in self.arguments]
         self.max_pos = arg_kinds.count(ARG_POS) + arg_kinds.count(ARG_OPT)
         self.body = body
         self.type = typ
         self.expanded = []
 
-        i2 = []  # type: List[AssignmentStmt]
         self.min_args = 0
-        for i in range(len(init)):
-            if init[i] is not None:
-                rvalue = init[i]
-                lvalue = NameExpr(args[i].name()).set_line(rvalue.line)
-                assign = AssignmentStmt([lvalue], rvalue)
-                assign.set_line(rvalue.line)
-                i2.append(assign)
-            else:
-                i2.append(None)
-                if i < self.max_fixed_argc():
-                    self.min_args = i + 1
-        self.init = i2
+        for i in range(len(self.arguments)):
+            if self.arguments[i] is None and i < self.max_fixed_argc():
+                self.min_args = i + 1
 
     def max_fixed_argc(self) -> int:
         return self.max_pos
 
     def set_line(self, target: Union[Token, int]) -> Node:
         super().set_line(target)
-        for n in self.args:
-            n.line = self.line
+        for arg in self.arguments:
+            arg.set_line(self.line)
         return self
-
-    def init_expressions(self) -> List[Node]:
-        res = []  # type: List[Node]
-        for i in self.init:
-            if i is not None:
-                res.append(i.rvalue)
-            else:
-                res.append(None)
-        return res
 
     def is_dynamic(self):
         return self.type is None
@@ -337,12 +354,10 @@ class FuncDef(FuncItem):
 
     def __init__(self,
                  name: str,              # Function name
-                 args: List['Var'],      # Argument names
-                 arg_kinds: List[int],   # Arguments kinds (nodes.ARG_*)
-                 init: List[Node],       # Initializers (each may be None)
+                 arguments: List[Argument],
                  body: 'Block',
                  typ: 'mypy.types.FunctionLike' = None) -> None:
-        super().__init__(args, arg_kinds, init, body, typ)
+        super().__init__(arguments, body, typ)
         self._name = name
 
     def name(self) -> str:
@@ -1704,14 +1719,17 @@ def function_type(func: FuncBase, fallback: 'mypy.types.Instance') -> 'mypy.type
         if name:
             name = '"{}"'.format(name)
         names = []  # type: List[str]
-        for arg in fdef.args:
-            names.append(arg.name())
-        return mypy.types.CallableType([mypy.types.AnyType()] * len(fdef.args),
-                                   fdef.arg_kinds,
-                                   names,
-                                   mypy.types.AnyType(),
-                                   fallback,
-                                   name)
+        for arg in fdef.arguments:
+            names.append(arg.variable.name())
+
+        return mypy.types.CallableType(
+            [mypy.types.AnyType()] * len(fdef.arguments),
+            [arg.kind for arg in fdef.arguments],
+            names,
+            mypy.types.AnyType(),
+            fallback,
+            name,
+        )
 
 
 def method_type_with_fallback(func: FuncBase,

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -26,7 +26,7 @@ from mypy.nodes import (
     FloatExpr, CallExpr, SuperExpr, MemberExpr, IndexExpr, SliceExpr, OpExpr,
     UnaryExpr, FuncExpr, TypeApplication, PrintStmt, ImportBase, ComparisonExpr,
     StarExpr, YieldFromStmt, YieldFromExpr, NonlocalDecl, DictionaryComprehension,
-    SetComprehension, ComplexExpr, EllipsisExpr, YieldExpr, ExecStmt
+    SetComprehension, ComplexExpr, EllipsisExpr, YieldExpr, ExecStmt, Argument
 )
 from mypy import defaults
 from mypy import nodes
@@ -83,20 +83,6 @@ def parse(source: Union[str, bytes], fnam: str = None, errors: Errors = None,
     tree.path = fnam
     tree.is_stub = is_stub_file
     return tree
-
-
-class Argument:
-    """Ideally this would be in nodes and be an actual node. However,
-    since its not yet used by FuncItem, etc, it makes sense to keep
-    it here so that it avoids confusion. It should be easily relocatable
-    in the future.
-    """
-    def __init__(self, variable: Var, type: Optional[Type],
-            initializer: Optional[Node], kind: int) -> None:
-        self.variable = variable
-        self.type = type
-        self.initializer = initializer
-        self.kind = kind
 
 
 class Parser:
@@ -401,10 +387,8 @@ class Parser:
         try:
             (name, args, typ, is_error) = self.parse_function_header(no_type_checks)
 
-            init = [arg.initializer for arg in args]
-            kinds = [arg.kind for arg in args]
+            arg_kinds = [arg.kind for arg in args]
             arg_names = [arg.variable.name() for arg in args]
-            arg_vars = [arg.variable for arg in args]
 
             body, comment_type = self.parse_block(allow_type=True)
             if comment_type:
@@ -413,24 +397,24 @@ class Parser:
                     self.errors.report(
                         def_tok.line, 'Function has duplicate type signatures')
                 sig = cast(CallableType, comment_type)
-                if is_method and len(sig.arg_kinds) < len(kinds):
-                    self.check_argument_kinds(kinds,
+                if is_method and len(sig.arg_kinds) < len(arg_kinds):
+                    self.check_argument_kinds(arg_kinds,
                                               [nodes.ARG_POS] + sig.arg_kinds,
                                               def_tok.line)
                     # Add implicit 'self' argument to signature.
                     first_arg = [AnyType()]  # type: List[Type]
                     typ = CallableType(
                         first_arg + sig.arg_types,
-                        kinds,
+                        arg_kinds,
                         arg_names,
                         sig.ret_type,
                         None)
                 else:
-                    self.check_argument_kinds(kinds, sig.arg_kinds,
+                    self.check_argument_kinds(arg_kinds, sig.arg_kinds,
                                               def_tok.line)
                     typ = CallableType(
                         sig.arg_types,
-                        kinds,
+                        arg_kinds,
                         arg_names,
                         sig.ret_type,
                         None)
@@ -440,7 +424,7 @@ class Parser:
             if is_error:
                 return None
 
-            node = FuncDef(name, arg_vars, kinds, init, body, typ)
+            node = FuncDef(name, args, body, typ)
             node.set_line(def_tok)
             return node
         finally:
@@ -522,7 +506,7 @@ class Parser:
 
     def build_func_annotation(self, ret_type: Type, args: List[Argument],
             line: int, is_default_ret: bool = False) -> CallableType:
-        arg_types = [arg.type for arg in args]
+        arg_types = [arg.type_annotation for arg in args]
         # Are there any type annotations?
         if ((ret_type and not is_default_ret)
                 or arg_types != [None] * len(arg_types)):
@@ -649,7 +633,7 @@ class Parser:
     def construct_function_type(self, args: List[Argument], ret_type: Type,
                                 line: int) -> CallableType:
         # Complete the type annotation by replacing omitted types with 'Any'.
-        arg_types = [arg.type for arg in args]
+        arg_types = [arg.type_annotation for arg in args]
         for i in range(len(arg_types)):
             if arg_types[i] is None:
                 arg_types[i] = AnyType()
@@ -1647,12 +1631,7 @@ class Parser:
         body = Block([ReturnStmt(expr).set_line(lambda_tok)])
         body.set_line(colon)
 
-        arg_vars = [arg.variable for arg in args]
-        arg_kinds = [arg.kind for arg in args]
-        arg_initializers = [arg.initializer for arg in args]
-
-        node = FuncExpr(arg_vars, arg_kinds, arg_initializers, body, typ)
-        return node
+        return FuncExpr(args, body, typ)
 
     # Helper methods
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -59,7 +59,7 @@ from mypy.nodes import (
     ComparisonExpr, StarExpr, ARG_POS, ARG_NAMED, MroError, type_aliases,
     YieldFromStmt, YieldFromExpr, NamedTupleExpr, NonlocalDecl,
     SetComprehension, DictionaryComprehension, TYPE_ALIAS, TypeAliasExpr,
-    YieldExpr, ExecStmt, COVARIANT, CONTRAVARIANT, INVARIANT
+    YieldExpr, ExecStmt, Argument, COVARIANT, CONTRAVARIANT, INVARIANT
 )
 from mypy.visitor import NodeVisitor
 from mypy.traverser import TraverserVisitor
@@ -231,7 +231,7 @@ class SemanticAnalyzer(NodeVisitor):
                             self.name_already_defined(defn.name(), defn)
                     self.type.names[defn.name()] = SymbolTableNode(MDEF, defn)
             if not defn.is_static:
-                if not defn.args:
+                if not defn.arguments:
                     self.fail('Method must have at least one argument', defn)
                 elif defn.type:
                     sig = cast(FunctionLike, defn.type)
@@ -370,22 +370,23 @@ class SemanticAnalyzer(NodeVisitor):
             if isinstance(defn, FuncDef):
                 defn.info = self.type
                 defn.type = set_callable_name(defn.type, defn)
-        for init in defn.init:
-            if init:
-                init.rvalue.accept(self)
+        for arg in defn.arguments:
+            if arg.initializer:
+                arg.initializer.accept(self)
         self.function_stack.append(defn)
         self.enter()
-        for v in defn.args:
-            self.add_local(v, defn)
-        for init_ in defn.init:
-            if init_:
-                init_.lvalues[0].accept(self)
+        for arg in defn.arguments:
+            self.add_local(arg.variable, defn)
+        for arg in defn.arguments:
+            if arg.initialization_statement:
+                lvalue = arg.initialization_statement.lvalues[0]
+                lvalue.accept(self)
 
         # The first argument of a non-static, non-class method is like 'self'
         # (though the name could be different), having the enclosing class's
         # instance type.
-        if is_method and not defn.is_static and not defn.is_class and defn.args:
-            defn.args[0].is_self = True
+        if is_method and not defn.is_static and not defn.is_class and defn.arguments:
+            defn.arguments[0].variable.is_self = True
 
         defn.body.accept(self)
         disable_typevars(tvarnodes)
@@ -423,9 +424,9 @@ class SemanticAnalyzer(NodeVisitor):
 
     def check_function_signature(self, fdef: FuncItem) -> None:
         sig = cast(CallableType, fdef.type)
-        if len(sig.arg_types) < len(fdef.args):
+        if len(sig.arg_types) < len(fdef.arguments):
             self.fail('Type signature has too few arguments', fdef)
-        elif len(sig.arg_types) > len(fdef.args):
+        elif len(sig.arg_types) > len(fdef.arguments):
             self.fail('Type signature has too many arguments', fdef)
 
     def visit_class_def(self, defn: ClassDef) -> None:
@@ -1302,14 +1303,15 @@ class SemanticAnalyzer(NodeVisitor):
         info.bases = [info.tuple_type.fallback]
         return info
 
+    def make_argument(self, name: str, type: Type) -> Argument:
+        return Argument(Var(name), type, None, ARG_POS)
+
     def make_namedtuple_init(self, info: TypeInfo, items: List[str],
                              types: List[Type]) -> FuncDef:
-        args = [Var(item) for item in items]
-        for arg, type in zip(args, types):
-            arg.type = type
+        args = [self.make_argument(item, type) for item, type in zip(items, types)]
         # TODO: Make sure that the self argument name is not visible?
-        args = [Var('__self')] + args
-        arg_kinds = [ARG_POS] * (len(items) + 1)
+        args = [Argument(Var('__self'), NoneTyp(), None, ARG_POS)] + args
+        arg_kinds = [arg.kind for arg in args]
         signature = CallableType([cast(Type, None)] + types,
                                  arg_kinds,
                                  ['__self'] + items,
@@ -1317,8 +1319,7 @@ class SemanticAnalyzer(NodeVisitor):
                                  self.named_type('__builtins__.function'),
                                  name=info.name())
         return FuncDef('__init__',
-                       args, arg_kinds,
-                       [None] * (len(items) + 1),
+                       args,
                        Block([]),
                        typ=signature)
 
@@ -1360,7 +1361,7 @@ class SemanticAnalyzer(NodeVisitor):
                 dec.func.is_property = True
                 dec.var.is_property = True
                 self.check_decorated_function_is_method('property', dec)
-                if len(dec.func.args) > 1:
+                if len(dec.func.arguments) > 1:
                     self.fail('Too many arguments', dec.func)
             elif refers_to_fullname(d, 'typing.no_type_check'):
                 dec.var.type = AnyType()

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -39,16 +39,17 @@ class StrConv(NodeVisitor[str]):
         args = []
         init = []
         extra = []
-        for i, kind in enumerate(o.arg_kinds):
+        for i, arg in enumerate(o.arguments):
+            kind = arg.kind
             if kind == mypy.nodes.ARG_POS:
-                args.append(o.args[i])
+                args.append(o.arguments[i].variable)
             elif kind in (mypy.nodes.ARG_OPT, mypy.nodes.ARG_NAMED):
-                args.append(o.args[i])
-                init.append(o.init[i])
+                args.append(o.arguments[i].variable)
+                init.append(o.arguments[i].initialization_statement)
             elif kind == mypy.nodes.ARG_STAR:
-                extra.append(('VarArg', [o.args[i]]))
+                extra.append(('VarArg', [o.arguments[i].variable]))
             elif kind == mypy.nodes.ARG_STAR2:
-                extra.append(('DictVarArg', [o.args[i]]))
+                extra.append(('DictVarArg', [o.arguments[i].variable]))
         a = []
         if args:
             a.append(('Args', args))
@@ -101,7 +102,7 @@ class StrConv(NodeVisitor[str]):
     def visit_func_def(self, o):
         a = self.func_helper(o)
         a.insert(0, o.name())
-        if mypy.nodes.ARG_NAMED in o.arg_kinds:
+        if mypy.nodes.ARG_NAMED in [arg.kind for arg in o.arguments]:
             a.insert(1, 'MaxPos({})'.format(o.max_pos))
         if o.is_abstract:
             a.insert(-1, 'Abstract')

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -186,9 +186,11 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         self.add("%sdef %s(" % (self._indent, o.name()))
         self.record_name(o.name())
         args = []
-        for i, (arg, kind) in enumerate(zip(o.args, o.arg_kinds)):
+        for i, arg_ in enumerate(o.arguments):
+            arg = arg_.variable
+            kind = arg_.kind
             name = arg.name()
-            init = o.init[i]
+            init = arg_.initialization_statement
             if init:
                 if kind == ARG_NAMED and '*' not in args:
                     args.append('*')

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -38,11 +38,14 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
             s.accept(self)
 
     def visit_func(self, o: FuncItem) -> T:
-        for i in o.init:
-            if i is not None:
-                i.accept(self)
-        for v in o.args:
-            self.visit_var(v)
+        for arg in o.arguments:
+            init = arg.initialization_statement
+            if init is not None:
+                init.accept(self)
+
+        for arg in o.arguments:
+            self.visit_var(arg.variable)
+
         o.body.accept(self)
 
     def visit_func_def(self, o: FuncDef) -> T:


### PR DESCRIPTION
Add a new node, consolidating the argument-type information from
FuncItem, which previously used parallel lists, into a list of
Argument.

Each argument contains:
  - The variable that it represents
  - The type annotation that was attached in the original AST. This
    is *not* the same as variable.type. (Hence why I named it something
    besides "type".
  - The initializer expression as a Node.
  - The initialization statement - this is the most similar to the old
    "init" list.

The initialization statement is optional and is generated
using the initializer.