### PR TITLE
Allow multisource builds within build manager.

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -916,6 +916,23 @@ def find_module(id: str, lib_path: List[str]) -> str:
     return None
 
 
+def find_modules_recursive(module: str, lib_path: List[str]) -> List[BuildSource]:
+    module_path = find_module(module, lib_path)
+    result = [BuildSource(None, module, None)]
+    if module_path.endswith(('__init__.py', '__init__.pyi')):
+        for item in os.listdir(os.path.dirname(module_path)):
+            abs_path = os.path.join(os.path.dirname(module_path), item)
+            if os.path.isdir(abs_path) and \
+                    (os.path.isfile(os.path.join(abs_path, '__init__.py')) or
+                    os.path.isfile(os.path.join(abs_path, '__init__.pyi'))):
+                result += find_modules_recursive(module + '.' + item, lib_path)
+            elif item != '__init__.py' and item != '__init__.pyi' and \
+                    item.endswith(('.py', '.pyi')):
+                result += find_modules_recursive(
+                    module + '.' + item.split('.')[0], lib_path)
+    return result
+
+
 def verify_module(id: str, path: str) -> bool:
     """Check that all packages containing id have a __init__ file."""
     if path.endswith(('__init__.py', '__init__.pyi')):

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 from os.path import dirname, basename
 
-from typing import Dict, List, Tuple, cast, Set, Union
+from typing import Dict, List, Tuple, cast, Set, Union, Optional
 
 from mypy.types import Type
 from mypy.nodes import MypyFile, Node, Import, ImportFrom, ImportAll
@@ -89,11 +89,30 @@ class BuildResult:
         self.types = types
 
 
-def build(program_path: str,
+class BuildSource:
+    def __init__(self, path: Optional[str], module: Optional[str],
+            text: Optional[str]) -> None:
+        self.path = path
+        self.module = module or '__main__'
+        self.text = text
+
+    def load(self, lib_path) -> Union[str, bytes]:
+        """Load the module if needed. This also has the side effect
+        of calculating the effective path for modules."""
+        if self.text is not None:
+            return self.text
+
+        self.path = self.path or lookup_program(self.module, lib_path)
+        return read_program(self.path)
+
+    @property
+    def effective_path(self) -> str:
+        """Return the effective path (ie, <string> if its from in memory)"""
+        return self.path or '<string>'
+
+
+def build(sources: List[BuildSource],
           target: int,
-          module: str = None,
-          argument: str = None,
-          program_text: Union[str, bytes] = None,
           alt_lib_path: str = None,
           bin_dir: str = None,
           pyversion: Tuple[int, int] = defaults.PYTHON3_VERSION,
@@ -109,11 +128,8 @@ def build(program_path: str,
     Return BuildResult if successful; otherwise raise CompileError.
 
     Args:
-      program_path: the path to the main source file (if module argument is
-        given, this can be None => will be looked up)
       target: select passes to perform (a build target constant, e.g. C)
-      module: name of the initial module; __main__ by default
-      program_text: the main source file contents; if omitted, read from file
+      sources: list of sources to build
       alt_lib_dir: an additional directory for looking up library modules
         (takes precedence over other directories)
       bin_dir: directory containing the mypy script, used for finding data
@@ -123,23 +139,27 @@ def build(program_path: str,
       flags: list of build options (e.g. COMPILE_ONLY)
     """
     flags = flags or []
-    module = module or '__main__'
 
     data_dir = default_data_dir(bin_dir)
 
     # Determine the default module search path.
-    lib_path = default_lib_path(data_dir, target, pyversion, python_path)
+    lib_path = default_lib_path(data_dir, pyversion, python_path)
 
     if TEST_BUILTINS in flags:
         # Use stub builtins (to speed up test cases and to make them easier to
         # debug).
         lib_path.insert(0, os.path.join(os.path.dirname(__file__), 'test', 'data', 'lib-stub'))
-    elif program_path:
-        # Include directory of the program file in the module search path.
-        lib_path.insert(
-            0, remove_cwd_prefix_from_path(dirname(program_path)))
     else:
-        # Building/running a module.
+        for source in sources:
+            if source.path:
+                # Include directory of the program file in the module search path.
+                lib_path.insert(
+                    0, remove_cwd_prefix_from_path(dirname(source.path)))
+
+        # Do this even if running as a file, for sanity (mainly because with
+        # multiple builds, there could be a mix of files/modules, so its easier
+        # to just define the semantics that we always add the current director
+        # to the lib_path
         lib_path.insert(0, os.getcwd())
 
     # If provided, insert the caller-supplied extra module path to the
@@ -147,13 +167,9 @@ def build(program_path: str,
     if alt_lib_path:
         lib_path.insert(0, alt_lib_path)
 
-    if program_text is None:
-        program_path = program_path or lookup_program(module, lib_path)
-        program_text = read_program(program_path)
-    else:
-        program_path = program_path or '<string>'
-
-    reports = Reports(program_path, data_dir, report_dirs)
+    # TODO Reports is global to a build manager but only supports a single "main file"
+    # Fix this.
+    reports = Reports(sources[0].effective_path, data_dir, report_dirs)
 
     # Construct a build manager object that performs all the stages of the
     # build in the correct order.
@@ -165,13 +181,19 @@ def build(program_path: str,
                            custom_typing_module=custom_typing_module,
                            reports=reports)
 
-    # Construct information that describes the initial file. __main__ is the
+    # Construct information that describes the initial files. __main__ is the
     # implicit module id and the import context is empty initially ([]).
-    info = StateInfo(program_path, module, [], manager)
-    # Perform the build by sending the file as new file (UnprocessedFile is the
+    initial_states = []  # type: List[UnprocessedFile]
+    for source in sources:
+        content = source.load(lib_path)
+        info = StateInfo(source.effective_path, source.module, [], manager)
+        initial_state = UnprocessedFile(info, content)
+        initial_states += [initial_state]
+
+    # Perform the build by sending the files as new file (UnprocessedFile is the
     # initial state of all files) to the manager. The manager will process the
     # file and all dependant modules recursively.
-    result = manager.process(UnprocessedFile(info, program_text))
+    result = manager.process(initial_states)
     reports.finish()
     return result
 
@@ -201,7 +223,7 @@ def default_data_dir(bin_dir: str) -> str:
         raise RuntimeError("Broken installation: can't determine base dir")
 
 
-def default_lib_path(data_dir: str, target: int, pyversion: Tuple[int, int],
+def default_lib_path(data_dir: str, pyversion: Tuple[int, int],
         python_path: bool) -> List[str]:
     """Return default standard library search paths."""
     # IDEA: Make this more portable.
@@ -335,7 +357,7 @@ class BuildManager:
         self.module_deps = {}  # type: Dict[Tuple[str, str], bool]
         self.missing_modules = set()  # type: Set[str]
 
-    def process(self, initial_state: 'UnprocessedFile') -> BuildResult:
+    def process(self, initial_states: List['UnprocessedFile']) -> BuildResult:
         """Perform a build.
 
         The argument is a state that represents the main program
@@ -343,8 +365,11 @@ class BuildManager:
         manager object.  The return values are identical to the return
         values of the build function.
         """
-        self.states.append(initial_state)
-        self.module_files[initial_state.id] = initial_state.path
+        self.states += initial_states
+        for initial_state in initial_states:
+            self.module_files[initial_state.id] = initial_state.path
+        for initial_state in initial_states:
+            initial_state.load_dependencies()
 
         # Process states in a loop until all files (states) have been
         # semantically analyzed or type checked (depending on target).
@@ -645,8 +670,8 @@ class UnprocessedFile(State):
     def __init__(self, info: StateInfo, program_text: Union[str, bytes]) -> None:
         super().__init__(info)
         self.program_text = program_text
-        trace('waiting {}'.format(info.path))
 
+    def load_dependencies(self):
         # Add surrounding package(s) as dependencies.
         for p in super_packages(self.id):
             if not self.import_module(p):
@@ -727,8 +752,10 @@ class UnprocessedFile(State):
         if text is not None:
             info = StateInfo(path, id, self.errors().import_context(),
                              self.manager)
-            self.manager.states.append(UnprocessedFile(info, text))
+            new_file = UnprocessedFile(info, text)
+            self.manager.states.append(new_file)
             self.manager.module_files[id] = path
+            new_file.load_dependencies()
             return True
         else:
             return False

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Tuple
 
 from mypy import build
 from mypy import defaults
+from mypy.build import BuildSource
 from mypy.errors import CompileError
 
 from mypy.version import __version__
@@ -38,10 +39,10 @@ def main(script_path: str) -> None:
         bin_dir = find_bin_directory(script_path)
     else:
         bin_dir = None
-    path, module, program_text, options = process_options(sys.argv[1:])
+    sources, options = process_options(sys.argv[1:])
     try:
         if options.target == build.TYPE_CHECK:
-            type_check_only(path, module, program_text, bin_dir, options)
+            type_check_only(sources, bin_dir, options)
         else:
             raise RuntimeError('unsupported target %d' % options.target)
     except CompileError as e:
@@ -74,14 +75,12 @@ def readlinkabs(link: str) -> str:
     return os.path.join(os.path.dirname(link), path)
 
 
-def type_check_only(path: str, module: str, program_text: str,
+def type_check_only(sources: List[BuildSource],
         bin_dir: str, options: Options) -> None:
     # Type check the program and dependencies and translate to Python.
-    build.build(path,
-                module=module,
-                program_text=program_text,
-                bin_dir=bin_dir,
+    build.build(sources=sources,
                 target=build.TYPE_CHECK,
+                bin_dir=bin_dir,
                 pyversion=options.pyversion,
                 custom_typing_module=options.custom_typing_module,
                 report_dirs=options.report_dirs,
@@ -89,7 +88,7 @@ def type_check_only(path: str, module: str, program_text: str,
                 python_path=options.python_path)
 
 
-def process_options(args: List[str]) -> Tuple[str, str, str, Options]:
+def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
     """Process command line arguments.
 
     Return (mypy program path (or None),
@@ -119,10 +118,10 @@ def process_options(args: List[str]) -> Tuple[str, str, str, Options]:
             args = args[2:]
         elif args[0] == '-m' and args[1:]:
             options.build_flags.append(build.MODULE)
-            return None, args[1], None, options
+            return [BuildSource(None, args[1], None)], options
         elif args[0] == '-c' and args[1:]:
             options.build_flags.append(build.PROGRAM_TEXT)
-            return None, None, args[1], options
+            return [BuildSource(None, None, args[1])], options
         elif args[0] in ('-h', '--help'):
             help = True
             args = args[1:]
@@ -165,7 +164,7 @@ def process_options(args: List[str]) -> Tuple[str, str, str, Options]:
         usage('Python version 2 (or --py2) specified, '
               'but --use-python-path will search in sys.path of Python 3')
 
-    return args[0], None, None, options
+    return [BuildSource(args[0], None, None)], options
 
 
 # Don't generate this from mypy.reports, not all are meant to be public.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -119,6 +119,9 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
         elif args[0] == '-m' and args[1:]:
             options.build_flags.append(build.MODULE)
             return [BuildSource(None, args[1], None)], options
+        elif args[0] == '-p' and args[1:]:
+            options.build_flags.append(build.MODULE)
+            return build.find_modules_recursive(args[1], [os.getcwd()]), options
         elif args[0] == '-c' and args[1:]:
             options.build_flags.append(build.PROGRAM_TEXT)
             return [BuildSource(None, None, args[1])], options

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -8,6 +8,7 @@ from typing import Tuple
 
 from mypy import build
 import mypy.myunit  # for mutable globals (ick!)
+from mypy.build import BuildSource
 from mypy.myunit import Suite
 from mypy.test.config import test_temp_dir, test_data_prefix
 from mypy.test.data import parse_test_cases
@@ -67,11 +68,10 @@ class TypeCheckSuite(Suite):
         pyversion = testcase_pyversion(testcase.file, testcase.name)
         program_text = '\n'.join(testcase.input)
         module_name, program_name, program_text = self.parse_options(program_text)
+        source = BuildSource(program_name, module_name, program_text)
         try:
-            build.build(program_name,
-                        target=build.TYPE_CHECK,
-                        module=module_name,
-                        program_text=program_text,
+            build.build(target=build.TYPE_CHECK,
+                        sources=[source],
                         pyversion=pyversion,
                         flags=[build.TEST_BUILTINS],
                         alt_lib_path=test_temp_dir)

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -5,6 +5,7 @@ import os.path
 from typing import Dict, List
 
 from mypy import build
+from mypy.build import BuildSource
 from mypy.myunit import Suite
 from mypy.test.helpers import assert_string_arrays_equal, testfile_pyversion
 from mypy.test.data import parse_test_cases
@@ -46,9 +47,8 @@ def test_semanal(testcase):
 
     try:
         src = '\n'.join(testcase.input)
-        result = build.build('main',
-                             target=build.SEMANTIC_ANALYSIS,
-                             program_text=src,
+        result = build.build(target=build.SEMANTIC_ANALYSIS,
+                             sources=[BuildSource('main', None, src)],
                              pyversion=testfile_pyversion(testcase.file),
                              flags=[build.TEST_BUILTINS],
                              alt_lib_path=test_temp_dir)
@@ -96,9 +96,8 @@ def test_semanal_error(testcase):
 
     try:
         src = '\n'.join(testcase.input)
-        build.build('main',
-                    target=build.SEMANTIC_ANALYSIS,
-                    program_text=src,
+        build.build(target=build.SEMANTIC_ANALYSIS,
+                    sources=[BuildSource('main', None, src)],
                     flags=[build.TEST_BUILTINS],
                     alt_lib_path=test_temp_dir)
         raise AssertionError('No errors reported in {}, line {}'.format(
@@ -140,9 +139,8 @@ class SemAnalSymtableSuite(Suite):
         try:
             # Build test case input.
             src = '\n'.join(testcase.input)
-            result = build.build('main',
-                                 target=build.SEMANTIC_ANALYSIS,
-                                 program_text=src,
+            result = build.build(target=build.SEMANTIC_ANALYSIS,
+                                 sources=[BuildSource('main', None, src)],
                                  flags=[build.TEST_BUILTINS],
                                  alt_lib_path=test_temp_dir)
             # The output is the symbol table converted into a string.
@@ -179,9 +177,8 @@ class SemAnalTypeInfoSuite(Suite):
         try:
             # Build test case input.
             src = '\n'.join(testcase.input)
-            result = build.build('main',
-                                 target=build.SEMANTIC_ANALYSIS,
-                                 program_text=src,
+            result = build.build(target=build.SEMANTIC_ANALYSIS,
+                                 sources=[BuildSource('main', None, src)],
                                  flags=[build.TEST_BUILTINS],
                                  alt_lib_path=test_temp_dir)
 

--- a/mypy/test/testtransform.py
+++ b/mypy/test/testtransform.py
@@ -5,6 +5,7 @@ import os.path
 from typing import Dict, List
 
 from mypy import build
+from mypy.build import BuildSource
 from mypy.myunit import Suite
 from mypy.test.helpers import assert_string_arrays_equal, testfile_pyversion
 from mypy.test.data import parse_test_cases
@@ -38,9 +39,8 @@ def test_transform(testcase):
 
     try:
         src = '\n'.join(testcase.input)
-        result = build.build('main',
-                             target=build.SEMANTIC_ANALYSIS,
-                             program_text=src,
+        result = build.build(target=build.SEMANTIC_ANALYSIS,
+                             sources=[BuildSource('main', None, src)],
                              pyversion=testfile_pyversion(testcase.file),
                              flags=[build.TEST_BUILTINS],
                              alt_lib_path=test_temp_dir)

--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -6,6 +6,7 @@ import re
 import typing
 
 from mypy import build
+from mypy.build import BuildSource
 from mypy.myunit import Suite
 from mypy.test import config
 from mypy.test.data import parse_test_cases
@@ -36,9 +37,8 @@ class TypeExportSuite(Suite):
                 mask = '(' + line[2:].strip() + ')$'
 
             src = '\n'.join(testcase.input)
-            result = build.build(program_path='main',
-                                 target=build.TYPE_CHECK,
-                                 program_text=src,
+            result = build.build(target=build.TYPE_CHECK,
+                                 sources=[BuildSource('main', None, src)],
                                  flags=[build.TEST_BUILTINS],
                                  alt_lib_path=config.test_temp_dir)
             map = result.types


### PR DESCRIPTION
In the current world, this is only a refactor because we only actually
pass in a list of a single item - minus one small behavioral change
regarding lib_path that makes life more sane in a multisource world.

Refactors out the source information into a BuildSource class. Make
build() accept a list of build sources, and make BuildManager.process
accept a list of initial states (which are basically unprocessed-files
created from a build source in build()).