### PR TITLE
Fix yield from semantics for AnyType

### DIFF
--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -725,6 +725,12 @@ def g() -> Iterator[str]:
     yield "g2 more spam"
 [out]
 
+[case testYieldFromAny]
+from typing import Iterator
+def f(a):
+    b = yield from a
+    return b
+[out]
 
 -- With statement
 -- --------------


### PR DESCRIPTION
Revised version of someone else's PR that also should also
avoid a crash when the type isn't some sort of Instance. Avoids
cast using the now-possible `if not isinstance` construction.