### PR TITLE
Only print test output on failures or verbose mode.

### DIFF
--- a/mypy/waiter.py
+++ b/mypy/waiter.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, Tuple
 
 import os
 import pipes
-from subprocess import Popen
+from subprocess import Popen, PIPE, STDOUT
 import sys
 
 
@@ -20,7 +20,7 @@ class LazySubprocess:
         self.env = env
 
     def __call__(self) -> Popen:
-        return Popen(self.args, cwd=self.cwd, env=self.env)
+        return Popen(self.args, cwd=self.cwd, env=self.env, stdout=PIPE, stderr=STDOUT)
 
 
 class Noter:
@@ -159,6 +159,13 @@ class Waiter:
                 fail_type = None
             else:
                 fail_type = 'UPASS'
+
+        if fail_type is not None or self.verbosity >= 1:
+            if self.verbosity <= 0:
+                sys.stdout.write('\n')
+            sys.stdout.write('%-8s #%d %s\n' % (fail_type or 'PASS', num, name))
+            sys.stdout.buffer.write(proc.stdout.read())
+            sys.stdout.flush()
 
         if fail_type is not None:
             return ['%8s %s' % (fail_type, name)]


### PR DESCRIPTION
First, we shouldn't have multiple processes outputting to the same
stdout/stderr filehandles. This made the output completely wonky and
difficult to interpret. Instead use subprocess.PIPE to make a new
stdout, and use subprocess.STDOUT to redirect the subprocesses' stderr
to stdout. Since we don't know if we are going to print these until the
process exits, we need to combine them so as to not lose their ordering.

If the process failed or we are running in verbose mode, only then do we
print the output. Because all prints to real stdout are from the main
thread, this removes the ability for all of the different processes to
interleave their output in weird ways.