### PR TITLE
Don't set breaking_out to False after visiting call expression.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1737,9 +1737,7 @@ class TypeChecker(NodeVisitor[Type]):
         return self.expr_checker.visit_name_expr(e)
 
     def visit_call_expr(self, e: CallExpr) -> Type:
-        result = self.expr_checker.visit_call_expr(e)
-        self.breaking_out = False
-        return result
+        return self.expr_checker.visit_call_expr(e)
 
     def visit_yield_from_expr(self, e: YieldFromExpr) -> Type:
         # result = self.expr_checker.visit_yield_from_expr(e)

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -6,7 +6,6 @@
 import typing
 def f() -> 'A':
     return A()
-    return B()
 def g() -> 'B':
     return A()
 class A:
@@ -14,10 +13,8 @@ class A:
 class B:
     pass
 [out]
-main: note: In function "f":
-main:4: error: Incompatible return value type: expected __main__.A, got __main__.B
 main: note: In function "g":
-main:6: error: Incompatible return value type: expected __main__.B, got __main__.A
+main:5: error: Incompatible return value type: expected __main__.B, got __main__.A
 
 [case testReturnSubtype]
 import typing


### PR DESCRIPTION
I really don't know why I wrote that line in the first place, but it
seems completely wrong.  Removing it fixes bug #956.

This caused a test to fail.  The isinstance logic makes mypy skip
typechecking of dead code.  This change makes this more consistent,
causing the following to not be an error:

def foo() -> int:
    return foo()
    return 'a'

I changed the test to avoid this case.  We should probably decide what
we actually want to do about dead code and make appropriate tests.