### PR TITLE
bug fix: don't crash when git isn't installed

### DIFF
--- a/mypy/git.py
+++ b/mypy/git.py
@@ -19,6 +19,8 @@ def have_git() -> bool:
         return True
     except subprocess.CalledProcessError:
         return False
+    except FileNotFoundError:
+        return False
 
 
 def get_submodules(dir: str):


### PR DESCRIPTION
Don't crash when git isn't installed.

Fixes https://github.com/JukkaL/mypy/issues/959