### PR TITLE
fix base dir for win32

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -205,7 +205,7 @@ def default_data_dir(bin_dir: str) -> str:
         return os.path.dirname(os.path.dirname(__file__))
     base = os.path.basename(bin_dir)
     dir = os.path.dirname(bin_dir)
-    if (sys.platform == 'win32' and base.lower() == 'mypy'
+    if (sys.platform == 'win32' and base.lower() == 'scripts'
             and not os.path.isdir(os.path.join(dir, 'stubs'))):
         # Installed, on Windows.
         return os.path.join(dir, 'Lib', 'mypy')


### PR DESCRIPTION
This pull request is related to #653, it is the fix for [windows platform](https://github.com/JukkaL/mypy/issues/653#issuecomment-148637458).

I confirmed it works fine on the below environments.

* Windows 8.1
* Python 3.5/3.4
* virtualenv/anaconda
