### PR TITLE
Fix missing type (but puzzled why)

### DIFF
--- a/mypy/lex.py
+++ b/mypy/lex.py
@@ -16,6 +16,8 @@ from typing import List, Callable, Dict, Any, Match, Pattern, Set, Union, Tuple
 class Token:
     """Base class for all tokens."""
 
+    line = 0
+
     def __init__(self, string: str, pre: str = '') -> None:
         """Initialize a token.
 


### PR DESCRIPTION
(Meant more to ask a question than to be merged, for now.)

This fixes the following type error when mypy is run against its
own implementation:

```
mypy/checker.py:10: note: In module imported here:
mypy/nodes.py: note: In member "set_line" of class "Node":
mypy/nodes.py:95: error: Cannot determine type of 'line'
```

I don't actually understand why this is necessary, though!
Based on http://mypy.readthedocs.org/en/latest/class_basics.html ,
it seems like the initialization `self.line = 0` in the class's
`__init__` ought to do the job.  What am I missing?