### PR TITLE
Support invoking mypy from setuptools

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -203,6 +203,10 @@ def default_data_dir(bin_dir: str) -> str:
     # TODO fix this logic
     if not bin_dir:
         # Default to directory containing this file's parent.
+        grandparent_dir = os.path.dirname(os.path.dirname(__file__))
+        # Running from within an egg, likely from setuptools.
+        if grandparent_dir.endswith('.egg'):
+            return os.path.join(grandparent_dir, 'lib', 'mypy')
         return os.path.dirname(os.path.dirname(__file__))
     base = os.path.basename(bin_dir)
     dir = os.path.dirname(bin_dir)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import os.path
 import sys
 
-from distutils.core import setup
+from setuptools import setup
 from mypy.version import __version__
 from mypy import git
 
@@ -69,6 +69,13 @@ classifiers = [
     'Topic :: Software Development',
 ]
 
+entry_points = {
+    'distutils.commands': [
+        'mypy = mypy.main:MyPyCommand'
+    ]
+}
+
+
 setup(name='mypy-lang',
       version=version,
       description=description,
@@ -84,4 +91,5 @@ setup(name='mypy-lang',
       scripts=['scripts/mypy'],
       data_files=data_files,
       classifiers=classifiers,
+      entry_points=entry_points,
       )


### PR DESCRIPTION
By default, this will typecheck all of the package modules.
We still need to figure out how to handle third-party modules.
Passing in `--mypy-args="--use-python-path"` will also include
any dependent modules, but nearly all of them fail to typecheck.

This will fix https://github.com/JukkaL/mypy/issues/992