### PR TITLE
Set breaking_out to False in try/except

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1598,6 +1598,7 @@ class TypeChecker(NodeVisitor[Type]):
         self.binder.try_frames.remove(len(self.binder.frames) - 2)
         if s.else_body:
             self.accept(s.else_body)
+        self.breaking_out = False
         changed, frame_on_completion = self.binder.pop_frame()
         completed_frames.append(frame_on_completion)
 
@@ -1609,11 +1610,7 @@ class TypeChecker(NodeVisitor[Type]):
                                           self.temp_node(t, s.vars[i]))
             self.binder.push_frame()
             self.accept(s.handlers[i])
-            changed, frame_on_completion = self.binder.pop_frame()
-            completed_frames.append(frame_on_completion)
-        if s.else_body:
-            self.binder.push_frame()
-            self.accept(s.else_body)
+            self.breaking_out = False
             changed, frame_on_completion = self.binder.pop_frame()
             completed_frames.append(frame_on_completion)
 

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -460,6 +460,18 @@ main: note: In function "f":
 main:5: error: Incompatible types in assignment (expression has type "object", variable has type "BaseException")
 main:8: error: Incompatible types in assignment (expression has type "BaseException", variable has type "Err")
 
+[case testTryExceptFlow]
+def f() -> None:
+  x = 1
+  try:
+    pass
+  except:
+    raise
+  x + 'a' # E: Unsupported left operand type for + ("int")
+[builtins fixtures/exception.py]
+[out]
+main: note: In function "f":
+
 [case testTryWithElse]
 import typing
 try: pass


### PR DESCRIPTION
We failed to set breaking_out to false in try/except, causing us to
not typecheck the rest of the function if the code raises an exception
or returns in the middle of one of the parts (#1040).

This commit also stops us from checking else_body twice.

Unlike in if/elif/else chains, we do not keep track of which parts of
the code path break out and which continue.  finally: blocks make this
tricky, and the main benefit was isinstance checks which don't happen
here.