### PR TITLE
Improve verbose formatting to disambiguate types of the same name.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1916,11 +1916,12 @@ class TypeChecker(NodeVisitor[Type]):
                 self.msg.does_not_return_value(subtype, context)
             else:
                 extra_info = []  # type: List[str]
-                if subtype_label is not None:
-                    extra_info.append(subtype_label + ' ' + self.msg.format(subtype, verbose=True))
-                if supertype_label is not None:
-                    extra_info.append(supertype_label + ' ' + self.msg.format(supertype,
-                                                                              verbose=True))
+                if subtype_label is not None or supertype_label is not None:
+                    subtype_str, supertype_str = self.msg.format_distinctly(subtype, supertype)
+                    if subtype_label is not None:
+                        extra_info.append(subtype_label + ' ' + subtype_str)
+                    if supertype_label is not None:
+                        extra_info.append(supertype_label + ' ' + supertype_str)
                 if extra_info:
                     msg += ' (' + ', '.join(extra_info) + ')'
                 self.fail(msg, context)

--- a/mypy/test/data/check-dynamic-typing.test
+++ b/mypy/test/data/check-dynamic-typing.test
@@ -485,7 +485,7 @@ class A:
   def __init__(self, a, b): pass
 [out]
 main:6: error: Too few arguments for "A"
-main:7: error: Incompatible types in assignment (expression has type "A" (type object), variable has type Callable[[A], A])
+main:7: error: Incompatible types in assignment (expression has type "A", variable has type Callable[[A], A])
 
 [case testUsingImplicitTypeObjectWithIs]
 


### PR DESCRIPTION
Previously, foo.Bar and baz.Bar would both be formatted as "Bar" in
error messages, which causes confusing errors like the following:

error: Argument 2 to "quux" has incompatible type "Bar"; expected "Bar"