### PR TITLE
Add --silent-imports flag which prevents importing non-stub modules not listed on the command line

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -158,6 +158,9 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
         elif args[0] == '--use-python-path':
             options.python_path = True
             args = args[1:]
+        elif args[0] in ('--silent-imports', '--silent'):
+            options.build_flags.append(build.SILENT_IMPORTS)
+            args = args[1:]
         elif args[0] == '--version':
             ver = True
             args = args[1:]


### PR DESCRIPTION
See issue #1043. The name of the flag is debatable. I've found this very useful for our current beta customer.