### PR TITLE
runtests: add -j option, and better handle parallelism in display

### DIFF
--- a/mypy/waiter.py
+++ b/mypy/waiter.py
@@ -98,9 +98,8 @@ class Noter:
 
     def update(self) -> None:
         pending = self.total - self.passes - self.fails - len(self.running)
-        running = ', '.join('#%d' % r for r in sorted(self.running))
-        args = (self.passes, self.fails, pending, running)
-        msg = 'passed %d, failed %d, pending %d; running {%s}' % args
+        args = (self.passes, self.fails, pending, len(self.running))
+        msg = 'passed %d, failed %d, pending %d; running %d' % args
         self.message(msg)
 
     def clear(self) -> None:


### PR DESCRIPTION
The list of job numbers isn't very interesting, and it's
long -- which tends to overflow the width of the terminal and
cause the '\r' trick to fail to reuse the line, so the
output becomes long.
