### PR TITLE
Fix #1082 -- internal error when updating partial type from outer scope.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -75,8 +75,9 @@ class ExpressionChecker:
             result = self.analyze_var_ref(node, e)
             if isinstance(result, PartialType):
                 partial_types = self.chk.partial_types[-1]
-                context = partial_types[node]
-                self.msg.fail(messages.NEED_ANNOTATION_FOR_VAR, context)
+                if node in partial_types:
+                    context = partial_types[node]
+                    self.msg.fail(messages.NEED_ANNOTATION_FOR_VAR, context)
                 result = AnyType()
         elif isinstance(node, FuncDef):
             # Reference to a global function.

--- a/mypy/test/data/check-inference.test
+++ b/mypy/test/data/check-inference.test
@@ -1191,6 +1191,13 @@ b[{}] = 1
 [builtins fixtures/dict.py]
 [out]
 
+[case testInferDictInitializedToEmptyAndUpdatedFromMethod]
+map = {}  # E: Need type annotation for variable
+def add():
+    map[1] = 2
+[builtins fixtures/dict.py]
+[out]
+
 [case testSpecialCaseEmptyListInitialization]
 def f(blocks: Any): # E: Name 'Any' is not defined
     to_process = [] # E: Need type annotation for variable


### PR DESCRIPTION
It seems we get another error from the outer scope, so I am just suppressing the error here. An alternative would be to walk down the list of contexts. That's the version I posted in the issue. But it bothers me that it produces two errors:
```
things = {}
def add():
    things[1] = 2
```
Produces
```
main: note: In function "add":
main:1: error: Need type annotation for variable
main: note: At top level:
main:1: error: Need type annotation for variable
```
