### PR TITLE
Fix #1081. When comparing template to actual arg types, stop at shortest.

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -225,11 +225,10 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             # We can't infer constraints from arguments if the template is Callable[..., T] (with
             # literal '...').
             if not template.is_ellipsis_args:
-                for i in range(len(template.arg_types)):
+                # The lengths should match, but don't crash (it will error elsewhere).
+                for t, a in zip(template.arg_types, cactual.arg_types):
                     # Negate constraints due function argument type contravariance.
-                    res.extend(negate_constraints(infer_constraints(
-                        template.arg_types[i], cactual.arg_types[i],
-                        self.direction)))
+                    res.extend(negate_constraints(infer_constraints(t, a, self.direction)))
             res.extend(infer_constraints(template.ret_type, cactual.ret_type,
                                          self.direction))
             return res

--- a/mypy/test/data/check-functions.test
+++ b/mypy/test/data/check-functions.test
@@ -178,6 +178,15 @@ def f(x: B) -> B: pass
 @overload
 def f(x: C) -> C: pass
 
+[case testInferConstraintsUnequalLengths]
+from typing import Any, Callable, List
+def f(fields: List[Callable[[Any], Any]]): pass
+class C: pass
+f([C])  # E: List item 0 has incompatible type
+class D:
+    def __init__(self, a, b): pass
+f([D])  # E: List item 0 has incompatible type
+[builtins fixtures/list.py]
 
 -- Default argument values
 -- -----------------------


### PR DESCRIPTION
Another crash fix. (I'm not sure if I put the test in the right place or if this is even the right fix, but it does stop the crash and return a reasonable error.)