### PR TITLE
Fix #815 -- defaultdict(list).

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -45,6 +45,9 @@ def is_subtype(left: Type, right: Type,
     elif isinstance(right, UnionType) and not isinstance(left, UnionType):
         return any(is_subtype(left, item, type_parameter_checker)
                    for item in cast(UnionType, right).items)
+    elif isinstance(left, TypeVarType) and isinstance(right, NoneTyp):
+        # This isn't very principled, but makes cases like defaultdict(list) work.
+        return True
     else:
         return left.accept(SubtypeVisitor(right, type_parameter_checker))
 

--- a/mypy/test/data/check-generic-subtyping.test
+++ b/mypy/test/data/check-generic-subtyping.test
@@ -629,6 +629,16 @@ s, s = Nums() # E: Incompatible types in assignment (expression has type "int", 
 [builtins fixtures/for.py]
 [out]
 
+[case testDefaultDictCase]
+# Simplest case similar to defaultdict(list).
+from typing import TypeVar, Generic, Callable
+T = TypeVar('T')
+class Item(Generic[T]):
+    def __init__(self) -> None: ...
+class Container(Generic[T]):
+    def __init__(self, factory: Callable[[], T]) -> None: ...
+Container(Item)
+
 
 -- Variance
 -- --------


### PR DESCRIPTION
I traced through a minimal example until I found that somewhere we're asking for equivalence between a type variable and an erased type variable ('None'), IIRC for the return value of the callable. But all I know is that adding this silences the example and doesn't break any other tests. There may well be a deeper cause (it reminds me of our pair programming session Wednesday where we tried renumbering type variables in various places).