### PR TITLE
Fix #1033. Don't report internal error when using a name that could not be imported.

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -60,6 +60,8 @@ node_kinds = {
     MODULE_REF: 'ModuleRef',
     UNBOUND_TVAR: 'UnboundTvar',
     BOUND_TVAR: 'Tvar',
+    TYPE_ALIAS: 'TypeAlias',
+    UNBOUND_IMPORTED: 'UnboundImported',
 }
 
 

--- a/mypy/test/data/check-modules.test
+++ b/mypy/test/data/check-modules.test
@@ -594,3 +594,17 @@ None + 1  # Does not generate error, as this file won't be analyzed.
 import m.a
 [file m/a.py]
 [out]
+
+
+-- Misc
+
+[case testInheritFromBadImport]
+# cmd: mypy -m bar
+[file foo.py]
+pass
+[file bar.py]
+from foo import B
+class C(B):
+    pass
+[out]
+tmp/bar.py:1: error: Module has no attribute 'B'

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -8,7 +8,8 @@ from mypy.types import (
     EllipsisType
 )
 from mypy.nodes import (
-    GDEF, TYPE_ALIAS, TypeInfo, Context, SymbolTableNode, BOUND_TVAR, TypeVarExpr, Var, Node,
+    GDEF, BOUND_TVAR, TYPE_ALIAS, UNBOUND_IMPORTED,
+    TypeInfo, Context, SymbolTableNode, TypeVarExpr, Var, Node,
     IndexExpr, NameExpr, TupleExpr, RefExpr
 )
 from mypy.sametypes import is_same_type
@@ -74,7 +75,9 @@ class TypeAnalyser(TypeVisitor[Type]):
         sym = self.lookup(t.name, t)
         if sym is not None:
             if sym.node is None:
-                self.fail('Internal error (node is None, kind={})'.format(sym.kind), t)
+                # UNBOUND_IMPORTED can happen if an unknown name was imported.
+                if sym.kind != UNBOUND_IMPORTED:
+                    self.fail('Internal error (node is None, kind={})'.format(sym.kind), t)
                 return AnyType()
             fullname = sym.node.fullname()
             if sym.kind == BOUND_TVAR:


### PR DESCRIPTION
Also fixed SymbolTableNode.__str__() by adding some missing cases to node_kinds.