### PR TITLE
Fix #1008. Improve check for "# type: ignore".

### DIFF
--- a/mypy/lex.py
+++ b/mypy/lex.py
@@ -382,7 +382,7 @@ class Lexer:
                                   not isinstance(self.tok[-1], Dedent)):
             self.add_token(Break(''))
 
-        # Attack any dangling comments/whitespace to a final Break token.
+        # Attach any dangling comments/whitespace to a final Break token.
         if self.tok and isinstance(self.tok[-1], Break):
             self.tok[-1].string += self.pre_whitespace
             self.pre_whitespace = ''

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -1875,6 +1875,7 @@ class Parser:
         return typ
 
     annotation_prefix_re = re.compile(r'#\s*type:')
+    ignore_prefix_re = re.compile(r'ignore\b')
 
     def parse_type_comment(self, token: Token, signature: bool) -> Type:
         """Parse a '# type: ...' annotation.
@@ -1885,7 +1886,7 @@ class Parser:
         whitespace_or_comments = token.rep().strip()
         if self.annotation_prefix_re.match(whitespace_or_comments):
             type_as_str = whitespace_or_comments.split(':', 1)[1].strip()
-            if type_as_str == 'ignore':
+            if self.ignore_prefix_re.match(type_as_str):
                 # Actually a "# type: ignore" annotation -> not a type.
                 return None
             tokens = lex.lex(type_as_str, token.line)[0]

--- a/mypy/test/data/check-ignore.test
+++ b/mypy/test/data/check-ignore.test
@@ -140,3 +140,9 @@ class D(C):
         self.g(1)
 [out]
 main: note: In member "f" of class "D":
+
+[case testIgnoreWithFollowingIndentedComment]
+if 1:  # type: ignore
+    # blah
+    pass
+[out]


### PR DESCRIPTION
This one was fun to debug and simple to fix. The check for whether we're looking at `# type: ignore` was too simplistic -- it just checked whether the string after `# type:` was equal to `'ignore'`, but this ignored (!) the possibility of a trailing comment.

In most cases the parser would then end up parsing everything as the expression `ignore` which somehow ends up being ignored later (I didn't figure out why). But if we're looking at an indent, the parser expects a type signature, e.g. `(int, int) -> int`, and complains at seeing just a name.

What added to the confusion is that *any* `# type:` comment at the start of an indented block gets parsed this way -- not only after a `def` line. (I guess the parser doesn't know yet whether it's looking at a `def` or not when that choice needs to be made.)

Anyway, the fix was to widen the definition of when to ignore (!) `# type: ignore`. (Note that the code that actually looks for `# type: ignore` runs at some other stage.)