### PR TITLE
Avoid ever relying on a not-yet-initialized MRO

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1537,9 +1537,10 @@ class TypeInfo(SymbolNode):
         self.names = names
         self.defn = defn
         self.subtypes = set()
-        self.mro = []
         self.type_vars = []
         self.bases = []
+        # Leave self.mro uninitialized until we compute it for real,
+        # so we don't accidentally try to use it prematurely.
         self._fullname = defn.fullname
         self.is_abstract = False
         self.abstract_attributes = []


### PR DESCRIPTION
Inevitably we will sometimes be analyzing one piece of code while
a class it refers to has not yet been analyzed.  Let's do what
we can to avoid accidentally relying on the `mro` attribute in
that situation.

This has two parts:
 * initialize `self.mro` on a TypeInfo to None, so that any
   attempt to iterate through it will blow up loudly
 * when we do get around to computing the MRO, be sure to
   set it to [] in the event of an error so that code that
   legitimately runs after that point doesn't fail.

Then there was just one place we were actually iterating
through a not-yet-initialized MRO, in `lookup_qualified`,
and that already has logic to work around that situation.
So just tweak that logic to be a bit more proactive.