### PR TITLE
Don't check git submodule in subprocesses.

### DIFF
--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -57,11 +57,11 @@ def test_python_evaluation(testcase):
             # Skip, can't find a Python 2 interpreter.
             raise SkipTestCaseException()
         interpreter = python2_interpreter
-        args = ['--py2']
+        args = ['--py2', '-f']
         py2 = True
     else:
         interpreter = python3_path
-        args = []
+        args = ['-f']
         py2 = False
     # Write the program to a file.
     program = '_program.py'

--- a/runtests.py
+++ b/runtests.py
@@ -77,7 +77,7 @@ class Driver:
         if not self.allow(name):
             return
         largs = list(args)
-        largs[0:0] = [sys.executable, self.mypy]
+        largs[0:0] = [sys.executable, self.mypy, '-f']
         env = self.env
         self.waiter.add(LazySubprocess(name, largs, cwd=cwd, env=env))
 
@@ -99,7 +99,7 @@ class Driver:
         if not self.allow(name):
             return
         largs = list(args)
-        largs[0:0] = [sys.executable, self.mypy, '-m']
+        largs[0:0] = [sys.executable, self.mypy, '-f', '-m']
         env = self.env
         self.waiter.add(LazySubprocess(name, largs, cwd=cwd, env=env))
 
@@ -121,7 +121,7 @@ class Driver:
         if not self.allow(name):
             return
         largs = list(args)
-        largs[0:0] = [sys.executable, self.mypy, '-c']
+        largs[0:0] = [sys.executable, self.mypy, '-f', '-c']
         env = self.env
         self.waiter.add(LazySubprocess(name, largs, cwd=cwd, env=env))
 


### PR DESCRIPTION
Especially when doing "runtests.py --dirty-stubs", the various subprocesses started by runtests shouldn't bug you about a dirty submodule, either. However, it's never a good idea to do this check in a subprocess.

Hence, assume the parent process did all the git integrity checking needed, and stop subprocesses from calling the code in git.py by passing the "-f" option.