### PR TITLE
Generators should be allowed to return a subclass of Iterator.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1480,7 +1480,7 @@ class TypeChecker(NodeVisitor[Type]):
     def visit_yield_stmt(self, s: YieldStmt) -> Type:
         return_type = self.return_types[-1]
         if isinstance(return_type, Instance):
-            if return_type.type.fullname() != 'typing.Iterator':
+            if not is_subtype(return_type, self.named_type('typing.Iterable')):
                 self.fail(messages.INVALID_RETURN_TYPE_FOR_YIELD, s)
                 return None
             expected_item_type = return_type.args[0]

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -665,6 +665,13 @@ import typing
 def f():
     yield f
 
+[case testYieldIteratorSubclass]
+import typing
+T = typing.TypeVar('T')
+class G(typing.Iterator[T], typing.Generic[T]): pass
+def f() -> G[int]:
+    yield 42
+
 [case testWithInvalidInstanceReturnType]
 import typing
 def f() -> int:


### PR DESCRIPTION
I need this so I can declare generators that return an instance of typing.Generator (which was added somewhat recently).