### PR TITLE
Update README.md to fix installation instructions for Python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Mypy can be installed using pip:
 *Note that the package name is `mypy-lang`, not `mypy`.*
 
 Currently, the version of mypy on PYPI is not compatible with Python 3.5.
-f you run Python 3.5 install directly form git:
+If you run Python 3.5 install directly form git:
 
     $ pip3 install git+git://github.com/JukkaL/mypy.git
  

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Mypy can be installed using pip:
 
 *Note that the package name is `mypy-lang`, not `mypy`.*
 
+Currently, the version of mypy on PYPI is not compatible with Python 3.5.
+f you run Python 3.5 install directly form git:
+
+    $ pip3 install git+git://github.com/JukkaL/mypy.git
+ 
+
 Now, if Python on your system is configured properly (else see
 "Troubleshooting" below), you can type-check a program like this:
 


### PR DESCRIPTION
The current package on pypi is incompatible with Python 3.5. The solution until pypi is updated is to install directly from github (see https://github.com/JukkaL/mypy/issues/975). However, the README.md file doesn't mention it. I spent 30 minutes updating and reinstalling everything until I found the issue. This little change can save a lot of time for other people until the next release.