### PR TITLE
Fix the order in which builtins are loaded.

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -251,8 +251,8 @@ def default_lib_path(data_dir: str, pyversion: Tuple[int, int],
     # is that a module added with 3.4 will still be present in Python 3.5.
     versions = ["%d.%d" % (pyversion[0], minor)
                 for minor in reversed(range(pyversion[1] + 1))]
-    # E.g. for Python 3.5, try 2and3/, then 3/, then 3.5/, then 3.4/, 3.3/, ...
-    for v in ['2and3', str(pyversion[0])] + versions:
+    # E.g. for Python 3.2, try 3.2/, 3.1/, 3.0/, 3/, 2and3/.
+    for v in versions + [str(pyversion[0]), '2and3']:
         for lib_type in ['stdlib', 'builtins', 'third_party']:
             stubdir = os.path.join(data_dir, 'typeshed', lib_type, v)
             if os.path.isdir(stubdir):


### PR DESCRIPTION
Make it possible to overload a generic definition e.g. in
2and3/ (or 2/ or 3/) with a more specialized one in e.g. 3.5/.