### PR TITLE
Fix #1095

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -541,8 +541,7 @@ class ExpressionChecker:
             elif kind in [nodes.ARG_POS, nodes.ARG_OPT,
                           nodes.ARG_NAMED] and is_duplicate_mapping(
                     formal_to_actual[i], actual_kinds):
-                if (self.chk.typing_mode_full() or
-                        isinstance(actual_type, TupleType)):
+                if self.chk.typing_mode_full():
                     self.msg.duplicate_argument_value(callee, i, context)
             elif (kind == nodes.ARG_NAMED and formal_to_actual[i] and
                   actual_kinds[formal_to_actual[i][0]] != nodes.ARG_NAMED):

--- a/mypy/test/data/check-kwargs.test
+++ b/mypy/test/data/check-kwargs.test
@@ -75,6 +75,12 @@ f(A(), a=A()) # E: "f" gets multiple values for keyword argument "a"
 class A: pass
 class B: pass
 
+[case testGivingArgumentAsPositionalAndKeywordArg3]
+def f(a): pass
+
+def g():
+    f(1, a=1)
+
 [case testInvalidKeywordArgument]
 import typing
 def f(a: 'A') -> None: pass # N: "f" defined here


### PR DESCRIPTION
Removing the extra check showed no noticeable regressions, and it fixed the bug. I'm guessing it had something to do with Python 2 mode and:

```python
def f((a, b)): pass
```

or something?