### PR TITLE
Hopeful fix for #1002 (lxml trouble).

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -135,10 +135,8 @@ class MemoryXmlReporter(AbstractReporter):
                                  content=line_text[:-1])
         # Assumes a layout similar to what XmlReporter uses.
         xslt_path = os.path.relpath('mypy-html.xslt', path)
-        xml_pi = etree.ProcessingInstruction('xml', 'version="1.0" encoding="utf-8"')
         transform_pi = etree.ProcessingInstruction('xml-stylesheet',
                 'type="text/xsl" href="%s"' % cgi.escape(xslt_path, True))
-        root.addprevious(xml_pi)
         root.addprevious(transform_pi)
         self.schema.assertValid(doc)
 
@@ -162,10 +160,8 @@ class MemoryXmlReporter(AbstractReporter):
                              name=file_info.name,
                              module=file_info.module)
         xslt_path = os.path.relpath('mypy-html.xslt', '.')
-        xml_pi = etree.ProcessingInstruction('xml', 'version="1.0" encoding="utf-8"')
         transform_pi = etree.ProcessingInstruction('xml-stylesheet',
                 'type="text/xsl" href="%s"' % cgi.escape(xslt_path, True))
-        root.addprevious(xml_pi)
         root.addprevious(transform_pi)
         self.schema.assertValid(doc)
 


### PR DESCRIPTION
This prevents the stated error with lxml version 3.5.0. But the generated XML files don't contain `<?xml version="1.0" encoding="UTF-8" ?` -- is that a problem?