### PR TITLE
Generalize yield statement function type

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -30,7 +30,7 @@ BOOLEAN_EXPECTED_FOR_NOT = 'Boolean value expected for not operand'
 INVALID_EXCEPTION = 'Exception must be derived from BaseException'
 INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'
 INVALID_RETURN_TYPE_FOR_YIELD = \
-    'Generator or supertype function return type expected for "yield"'
+    'The return type of a generator function should be "Generator" or a supertype thereof'
 INVALID_RETURN_TYPE_FOR_YIELD_FROM = \
     'Iterable function return type expected for "yield from"'
 INCOMPATIBLE_TYPES = 'Incompatible types'

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -30,7 +30,7 @@ BOOLEAN_EXPECTED_FOR_NOT = 'Boolean value expected for not operand'
 INVALID_EXCEPTION = 'Exception must be derived from BaseException'
 INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'
 INVALID_RETURN_TYPE_FOR_YIELD = \
-    'Iterator function return type expected for "yield"'
+    'Generator or supertype function return type expected for "yield"'
 INVALID_RETURN_TYPE_FOR_YIELD_FROM = \
     'Iterable function return type expected for "yield from"'
 INCOMPATIBLE_TYPES = 'Incompatible types'

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -30,7 +30,7 @@ BOOLEAN_EXPECTED_FOR_NOT = 'Boolean value expected for not operand'
 INVALID_EXCEPTION = 'Exception must be derived from BaseException'
 INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'
 INVALID_RETURN_TYPE_FOR_YIELD = \
-    'The return type of a generator function should be "Generator" or a supertype thereof'
+    'The return type of a generator function should be "Generator" or one of its supertypes'
 INVALID_RETURN_TYPE_FOR_YIELD_FROM = \
     'Iterable function return type expected for "yield from"'
 INCOMPATIBLE_TYPES = 'Incompatible types'

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -676,7 +676,7 @@ def f() -> Any:
 [case testYieldInFunctionReturningFunction]
 from typing import Callable
 def f() -> Callable[[], None]:
-    yield object() # E: The return type of a generator function should be "Generator" or a supertype thereof
+    yield object() # E: The return type of a generator function should be "Generator" or one of its supertypes
 [out]
 main: note: In function "f":
 
@@ -688,7 +688,7 @@ def f():
 [case testWithInvalidInstanceReturnType]
 import typing
 def f() -> int:
-    yield 1 # E: The return type of a generator function should be "Generator" or a supertype thereof
+    yield 1 # E: The return type of a generator function should be "Generator" or one of its supertypes
 [builtins fixtures/for.py]
 [out]
 main: note: In function "f":

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -647,6 +647,26 @@ def f() -> Iterator[int]:
 [out]
 main: note: In function "f":
 
+[case testYieldInFunctionReturningGenerator]
+from typing import Generator
+def f() -> Generator[int, None, None]:
+    yield 1
+[builtins fixtures/for.py]
+[out]
+
+[case testYieldInFunctionReturningIterable]
+from typing import Iterable
+def f() -> Iterable[int]:
+    yield 1
+[builtins fixtures/for.py]
+[out]
+
+[case testYieldInFunctionReturningObject]
+def f() -> object:
+    yield 1
+[builtins fixtures/for.py]
+[out]
+
 [case testYieldInFunctionReturningAny]
 from typing import Any
 def f() -> Any:
@@ -656,7 +676,7 @@ def f() -> Any:
 [case testYieldInFunctionReturningFunction]
 from typing import Callable
 def f() -> Callable[[], None]:
-    yield object() # E: Iterator function return type expected for "yield"
+    yield object() # E: Generator or supertype function return type expected for "yield"
 [out]
 main: note: In function "f":
 
@@ -668,7 +688,7 @@ def f():
 [case testWithInvalidInstanceReturnType]
 import typing
 def f() -> int:
-    yield 1 # E: Iterator function return type expected for "yield"
+    yield 1 # E: Generator or supertype function return type expected for "yield"
 [builtins fixtures/for.py]
 [out]
 main: note: In function "f":

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -676,7 +676,7 @@ def f() -> Any:
 [case testYieldInFunctionReturningFunction]
 from typing import Callable
 def f() -> Callable[[], None]:
-    yield object() # E: Generator or supertype function return type expected for "yield"
+    yield object() # E: The return type of a generator function should be "Generator" or a supertype thereof
 [out]
 main: note: In function "f":
 
@@ -688,7 +688,7 @@ def f():
 [case testWithInvalidInstanceReturnType]
 import typing
 def f() -> int:
-    yield 1 # E: Generator or supertype function return type expected for "yield"
+    yield 1 # E: The return type of a generator function should be "Generator" or a supertype thereof
 [builtins fixtures/for.py]
 [out]
 main: note: In function "f":

--- a/mypy/test/data/fixtures/for.py
+++ b/mypy/test/data/fixtures/for.py
@@ -1,6 +1,6 @@
 # builtins stub used in for statement test cases
 
-from typing import TypeVar, Generic, Iterable, Iterator
+from typing import TypeVar, Generic, Iterable, Iterator, Generator
 from abc import abstractmethod, ABCMeta
 
 t = TypeVar('t')

--- a/mypy/test/data/lib-stub/typing.py
+++ b/mypy/test/data/lib-stub/typing.py
@@ -23,6 +23,8 @@ Dict = 0
 Set = 0
 
 T = TypeVar('T')
+U = TypeVar('U')
+V = TypeVar('V')
 
 class Container(Generic[T]):
     @abstractmethod
@@ -40,6 +42,16 @@ class Iterable(Generic[T]):
 class Iterator(Iterable[T], Generic[T]):
     @abstractmethod
     def __next__(self) -> T: pass
+
+class Generator(Iterator[T], Generic[T, U, V]):
+    @abstractmethod
+    def send(self, value: U) -> T: pass
+
+    @abstractmethod
+    def throw(self, typ: Any, val: Any=None, tb=None) -> None: pass
+
+    @abstractmethod
+    def close(self) -> None: pass
 
 class Sequence(Generic[T]):
     @abstractmethod


### PR DESCRIPTION
Functions containing yield statements can now return any supertype
of generator. This fixes #1011.

In making this pull request, I noticed that the allowed return types of functions containing `yield`s are different depending on whether or not the `yield` is a statement, expression, or a `yield from`.  I'll make a PR to make them all behave consistently next.