### PR TITLE
If a base class is Any, don't get default constructor signature from object. Fixes #1049.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1261,6 +1261,10 @@ class ExpressionChecker:
                 return AnyType()
             for base in e.info.mro[1:]:
                 if e.name in base.names or base == e.info.mro[-1]:
+                    if e.info.fallback_to_any and base == e.info.mro[-1]:
+                        # There's an undefined base class, and we're
+                        # at the end of the chain.  That's not an error.
+                        return AnyType()
                     return analyze_member_access(e.name, self_type(e.info), e,
                                                  is_lvalue, True,
                                                  self.named_type, self.msg,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -689,7 +689,7 @@ class SemanticAnalyzer(NodeVisitor):
             if isinstance(base, Instance):
                 defn.info.is_enum = base.type.fullname() == 'enum.Enum'
         # Add 'object' as implicit base if there is no other base class.
-        if (not defn.base_types and not defn.info.fallback_to_any and defn.fullname != 'builtins.object'):
+        if (not defn.base_types and defn.fullname != 'builtins.object'):
             obj = self.object_type()
             defn.base_types.insert(0, obj)
         defn.info.bases = defn.base_types
@@ -705,7 +705,7 @@ class SemanticAnalyzer(NodeVisitor):
         else:
             # If there are cyclic imports, we may be missing 'object' in
             # the MRO. Fix MRO if needed.
-            if defn.info.mro[-1].fullname() != 'builtins.object' and not defn.info.fallback_to_any:
+            if defn.info.mro[-1].fullname() != 'builtins.object':
                 defn.info.mro.append(self.object_type().type)
         # The property of falling back to Any is inherited.
         defn.info.fallback_to_any = any(baseinfo.fallback_to_any for baseinfo in defn.info.mro)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -689,7 +689,7 @@ class SemanticAnalyzer(NodeVisitor):
             if isinstance(base, Instance):
                 defn.info.is_enum = base.type.fullname() == 'enum.Enum'
         # Add 'object' as implicit base if there is no other base class.
-        if (not defn.base_types and defn.fullname != 'builtins.object'):
+        if (not defn.base_types and not defn.info.fallback_to_any and defn.fullname != 'builtins.object'):
             obj = self.object_type()
             defn.base_types.insert(0, obj)
         defn.info.bases = defn.base_types
@@ -705,7 +705,7 @@ class SemanticAnalyzer(NodeVisitor):
         else:
             # If there are cyclic imports, we may be missing 'object' in
             # the MRO. Fix MRO if needed.
-            if defn.info.mro[-1].fullname() != 'builtins.object':
+            if defn.info.mro[-1].fullname() != 'builtins.object' and not defn.info.fallback_to_any:
                 defn.info.mro.append(self.object_type().type)
         # The property of falling back to Any is inherited.
         defn.info.fallback_to_any = any(baseinfo.fallback_to_any for baseinfo in defn.info.mro)

--- a/mypy/test/data/check-classes.test
+++ b/mypy/test/data/check-classes.test
@@ -1342,3 +1342,12 @@ f(A) # E: Argument 1 to "f" has incompatible type "A" (type object); expected "A
 --   attribute inherited from superclass; assign in __init__
 --   refer to attribute before type has been inferred (the initialization in
 --   __init__ has not been analyzed)
+
+[case testAnyBaseClassUnconstrainsConstructor]
+from typing import Any
+B = None  # type: Any
+class C(B): pass
+C(0)
+C(arg=0)
+[out]
+

--- a/mypy/test/data/check-super.test
+++ b/mypy/test/data/check-super.test
@@ -100,3 +100,11 @@ main: note: In member "__new__" of class "B":
 main:8: error: Argument 2 to "__new__" of "A" has incompatible type "str"; expected "int"
 main: note: At top level:
 main:10: error: Argument 1 to "B" has incompatible type "int"; expected "str"
+
+[case testSuperWithUnknownBase]
+from typing import Any
+B = None  # type: Any
+class C(B):
+    def __init__(self, arg=0):
+        super(C, self).__init__(arg, arg=arg)
+[out]


### PR DESCRIPTION
This isn't very principled -- I ran the test case under the debugger until I found the two (!) places where object is inserted into the MRO, and skipped them if fallback_to_any is set.