### PR TITLE
Generator fixup

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -444,11 +444,10 @@ class TypeChecker(NodeVisitor[Type]):
                     self.msg.overloaded_signatures_overlap(i + 1, j + 2,
                                                            item.func)
 
-
-    def is_generator_return_type(self, typ : Type) -> bool:
+    def is_generator_return_type(self, typ: Type) -> bool:
         return is_subtype(self.named_generic_type('typing.Generator',
                                                   [AnyType(), AnyType(), AnyType()]),
-                          typ);
+                          typ)
 
     def get_generator_yield_type(self, return_type: Type) -> Type:
         if isinstance(return_type, AnyType):
@@ -501,7 +500,6 @@ class TypeChecker(NodeVisitor[Type]):
             # it's a supertype of Generator, so callers won't be able to see
             # the return type
             return AnyType()
-
 
     def visit_func_def(self, defn: FuncDef) -> Type:
         """Type check a function definition."""
@@ -1497,8 +1495,8 @@ class TypeChecker(NodeVisitor[Type]):
                         # Something similar will be needed to mix return and yield.
                         # If the function is a coroutine, wrap the return type in a Future.
                         typ = self.wrap_generic_type(cast(Instance, typ),
-                                                        cast(Instance, return_type),
-                                                        'asyncio.futures.Future', s)
+                                                     cast(Instance, return_type),
+                                                     'asyncio.futures.Future', s)
                     self.check_subtype(
                         typ, return_type, s,
                         messages.INCOMPATIBLE_RETURN_VALUE_TYPE
@@ -1918,7 +1916,6 @@ class TypeChecker(NodeVisitor[Type]):
         self.check_subtype(actual_item_type, expected_item_type, e,
                            messages.INCOMPATIBLE_TYPES_IN_YIELD_FROM,
                            'actual type', 'expected type')
-
 
     def visit_member_expr(self, e: MemberExpr) -> Type:
         return self.expr_checker.visit_member_expr(e)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -462,7 +462,7 @@ class TypeChecker(NodeVisitor[Type]):
         elif return_type.args:
             return return_type.args[0]
         else:
-            # if the declared supertype of `Generator` has no type
+            # if the function's declared supertype of Generator has no type
             # parameters (i.e. is `object`), then the yielded values can't
             # be accessed so any type is acceptable.
             return AnyType()
@@ -478,10 +478,10 @@ class TypeChecker(NodeVisitor[Type]):
             # same as above, but written as a separate branch so the typechecker can understand
             return AnyType()
         elif return_type.type.fullname() == 'typing.Generator':
+            # Generator is the only type which specifies the type of values it can receive
             return return_type.args[1]
         else:
-            # it's a supertype of Generator, so callers won't be able to see
-            # send it values
+            # it's a supertype of Generator, so callers won't be able to see send it values
             return Void()
 
     def get_generator_return_type(self, return_type: Type) -> Type:
@@ -495,10 +495,11 @@ class TypeChecker(NodeVisitor[Type]):
             # same as above, but written as a separate branch so the typechecker can understand
             return AnyType()
         elif return_type.type.fullname() == 'typing.Generator':
+            # Generator is the only type which specifies the type of values it
+            # returns into `yield from` expressions
             return return_type.args[2]
         else:
-            # it's a supertype of Generator, so callers won't be able to see
-            # the return type
+            # it's a supertype of Generator, so callers won't be able to see the return type
             return AnyType()
 
     def visit_func_def(self, defn: FuncDef) -> Type:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1497,11 +1497,6 @@ class TypeChecker(NodeVisitor[Type]):
                         + ": expected {}, got {}".format(return_type, typ)
                     )
             else:
-                # return without a value
-                # empty returns are valid in coroutines
-                if (self.function_stack[-1].is_coroutine):
-                    return None
-
                 # empty returns are valid in Generators with Any typed returns
                 if (self.function_stack[-1].is_generator and isinstance(return_type, AnyType)):
                     return None

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1196,12 +1196,6 @@ class ExpressionChecker:
                                args,
                                [nodes.ARG_POS] * len(args), e)[0]
 
-    def visit_yield_expr(self, e: YieldExpr) -> Type:
-        # TODO: Implement proper type checking of yield expressions.
-        if e.expr:
-            self.accept(e.expr)
-        return AnyType()
-
     def visit_func_expr(self, e: FuncExpr) -> Type:
         """Type check lambda expression."""
         inferred_type = self.infer_lambda_type_using_context(e)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -29,10 +29,11 @@ BOOLEAN_EXPECTED_FOR_UNTIL = 'Boolean value expected for until condition'
 BOOLEAN_EXPECTED_FOR_NOT = 'Boolean value expected for not operand'
 INVALID_EXCEPTION = 'Exception must be derived from BaseException'
 INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'
-INVALID_RETURN_TYPE_FOR_YIELD = \
+INVALID_RETURN_TYPE_FOR_GENERATOR = \
     'The return type of a generator function should be "Generator" or one of its supertypes'
-INVALID_RETURN_TYPE_FOR_YIELD_FROM = \
-    'Iterable function return type expected for "yield from"'
+INVALID_GENERATOR_RETURN_ITEM_TYPE = \
+    'The return type of a generator function must be None in its third type parameter in Python 2'
+YIELD_VALUE_EXPECTED = 'Yield value expected'
 INCOMPATIBLE_TYPES = 'Incompatible types'
 INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'
 INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -634,26 +634,6 @@ class AssertStmt(Node):
         return visitor.visit_assert_stmt(self)
 
 
-class YieldStmt(Node):
-    expr = None  # type: Node
-
-    def __init__(self, expr: Node) -> None:
-        self.expr = expr
-
-    def accept(self, visitor: NodeVisitor[T]) -> T:
-        return visitor.visit_yield_stmt(self)
-
-
-class YieldFromStmt(Node):
-    expr = None  # type: Node
-
-    def __init__(self, expr: Node) -> None:
-        self.expr = expr
-
-    def accept(self, visitor: NodeVisitor[T]) -> T:
-        return visitor.visit_yield_from_stmt(self)
-
-
 class DelStmt(Node):
     expr = None  # type: Node
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -323,7 +323,6 @@ class FuncItem(FuncBase):
     # Is this an overload variant of function with more than one overload variant?
     is_overload = False
     is_generator = False   # Contains a yield statement?
-    is_coroutine = False   # Contains @coroutine or yield from Future
     is_static = False      # Uses @staticmethod?
     is_class = False       # Uses @classmethod?
     # Variants of function with type variables with values expanded

--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -968,7 +968,7 @@ class Parser:
         if not isinstance(self.current(), Break):
             if self.current_str() == "from":
                 self.expect("from")
-                expr = self.parse_expression()  # Here comes when yield from is assigned to a variable
+                expr = self.parse_expression()  # when yield from is assigned to a variable
                 node = YieldFromExpr(expr)
             else:
                 if self.current_str() == ')':

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1447,7 +1447,6 @@ class SemanticAnalyzer(NodeVisitor):
                 self.check_decorated_function_is_method('abstractmethod', dec)
             elif refers_to_fullname(d, 'asyncio.tasks.coroutine'):
                 removed.append(i)
-                dec.func.is_coroutine = True
             elif refers_to_fullname(d, 'builtins.staticmethod'):
                 removed.append(i)
                 dec.func.is_static = True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -49,7 +49,7 @@ from mypy.nodes import (
     ClassDef, Var, GDEF, MODULE_REF, FuncItem, Import,
     ImportFrom, ImportAll, Block, LDEF, NameExpr, MemberExpr,
     IndexExpr, TupleExpr, ListExpr, ExpressionStmt, ReturnStmt,
-    RaiseStmt, YieldStmt, AssertStmt, OperatorAssignmentStmt, WhileStmt,
+    RaiseStmt, AssertStmt, OperatorAssignmentStmt, WhileStmt,
     ForStmt, BreakStmt, ContinueStmt, IfStmt, TryStmt, WithStmt, DelStmt,
     GlobalDecl, SuperExpr, DictExpr, CallExpr, RefExpr, OpExpr, UnaryExpr,
     SliceExpr, CastExpr, TypeApplication, Context, SymbolTable,
@@ -57,7 +57,7 @@ from mypy.nodes import (
     FuncExpr, MDEF, FuncBase, Decorator, SetExpr, TypeVarExpr,
     StrExpr, PrintStmt, ConditionalExpr, PromoteExpr,
     ComparisonExpr, StarExpr, ARG_POS, ARG_NAMED, MroError, type_aliases,
-    YieldFromStmt, YieldFromExpr, NamedTupleExpr, NonlocalDecl,
+    YieldFromExpr, NamedTupleExpr, NonlocalDecl,
     SetComprehension, DictionaryComprehension, TYPE_ALIAS, TypeAliasExpr,
     YieldExpr, ExecStmt, Argument, BackquoteExpr, ImportBase, COVARIANT, CONTRAVARIANT,
     INVARIANT, UNBOUND_IMPORTED
@@ -1504,20 +1504,6 @@ class SemanticAnalyzer(NodeVisitor):
         if s.from_expr:
             s.from_expr.accept(self)
 
-    def visit_yield_stmt(self, s: YieldStmt) -> None:
-        if not self.is_func_scope():
-            self.fail("'yield' outside function", s)
-        else:
-            self.function_stack[-1].is_generator = True
-        if s.expr:
-            s.expr.accept(self)
-
-    def visit_yield_from_stmt(self, s: YieldFromStmt) -> None:
-        if not self.is_func_scope():
-            self.fail("'yield from' outside function", s)
-        if s.expr:
-            s.expr.accept(self)
-
     def visit_assert_stmt(self, s: AssertStmt) -> None:
         if s.expr:
             s.expr.accept(self)
@@ -1681,6 +1667,8 @@ class SemanticAnalyzer(NodeVisitor):
     def visit_yield_from_expr(self, e: YieldFromExpr) -> None:
         if not self.is_func_scope():  # not sure
             self.fail("'yield from' outside function", e)
+        else:
+            self.function_stack[-1].is_generator = True
         if e.expr:
             e.expr.accept(self)
 
@@ -1909,6 +1897,10 @@ class SemanticAnalyzer(NodeVisitor):
         expr.type = self.anal_type(expr.type)
 
     def visit_yield_expr(self, expr: YieldExpr) -> None:
+        if not self.is_func_scope():
+            self.fail("'yield' outside function", expr)
+        else:
+            self.function_stack[-1].is_generator = True
         if expr.expr:
             expr.expr.accept(self)
 

--- a/mypy/test/data/check-expressions.test
+++ b/mypy/test/data/check-expressions.test
@@ -1322,8 +1322,10 @@ class str: pass
 def f(x: int) -> None:
     x = yield f('')
     x = 1
+[builtins fixtures/for.py]
 [out]
 main: note: In function "f":
+main:1: error: The return type of a generator function should be "Generator" or one of its supertypes
 main:2: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 
 [case testYieldExpressionWithNone]
@@ -1332,6 +1334,33 @@ def f(x: int) -> Iterator[None]:
     (yield)
 [builtins fixtures/for.py]
 [out]
+
+
+-- Yield from expression
+-- ----------------
+
+
+
+[case testYieldFromIteratorHasNoValue]
+from typing import Iterator
+def f() -> Iterator[int]:
+    yield 5
+def g() -> Iterator[int]:
+    a = yield from f()
+[out]
+main: note: In function "g":
+main:5: error: Function does not return a value
+
+[case testYieldFromGeneratorHasValue]
+from typing import Iterator, Generator
+def f() -> Generator[int, None, str]:
+    yield 5
+    return "ham"
+def g() -> Iterator[int]:
+    a = "string"
+    a = yield from f()
+[out]
+
 
 
 -- dict(x=y, ...)

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -51,6 +51,27 @@ def g() -> None:
 [out]
 main: note: In function "g":
 
+[case testReturnInGenerator]
+from typing import Generator
+def f() -> Generator[int, None, str]:
+    yield 1
+    return "foo"
+[out]
+
+[case testEmptyReturnInGenerator]
+from typing import Generator
+def f() -> Generator[int, None, str]:
+    yield 1
+    return  # E: Return value expected
+[out]
+main: note: In function "f":
+
+[case testReturnInIterator]
+from typing import Iterator
+def f() -> Iterator[int]:
+    yield 1
+    return "foo"
+[out]
 
 -- If statement
 -- ------------
@@ -675,8 +696,8 @@ def f() -> Any:
 
 [case testYieldInFunctionReturningFunction]
 from typing import Callable
-def f() -> Callable[[], None]:
-    yield object() # E: The return type of a generator function should be "Generator" or one of its supertypes
+def f() -> Callable[[], None]: # E: The return type of a generator function should be "Generator" or one of its supertypes
+    yield object()
 [out]
 main: note: In function "f":
 
@@ -687,8 +708,8 @@ def f():
 
 [case testWithInvalidInstanceReturnType]
 import typing
-def f() -> int:
-    yield 1 # E: The return type of a generator function should be "Generator" or one of its supertypes
+def f() -> int: # E: The return type of a generator function should be "Generator" or one of its supertypes
+    yield 1
 [builtins fixtures/for.py]
 [out]
 main: note: In function "f":
@@ -714,6 +735,22 @@ from typing import Iterator
 def f() -> Iterator[None]:
     yield
 [builtins fixtures/for.py]
+
+[case testYieldWithNoValueWhenValueRequired]
+from typing import Iterator
+def f() -> Iterator[int]:
+    yield  # E: Yield value expected
+[builtins fixtures/for.py]
+[out]
+main: note: In function "f":
+
+[case testYieldWithExplicitNone]
+from typing import Iterator
+def f() -> Iterator[None]:
+    yield None  # E: Incompatible types in yield (actual type None, expected type None)
+[builtins fixtures/for.py]
+[out]
+main: note: In function "f":
 
 
 -- Yield from statement
@@ -746,8 +783,8 @@ def f() -> Any:
 from typing import Iterator, Callable
 def g() -> Iterator[int]:
     yield 42
-def f() -> Callable[[], None]:
-    yield from g()  # E: Iterable function return type expected for "yield from"
+def f() -> Callable[[], None]:  # E: The return type of a generator function should be "Generator" or one of its supertypes
+    yield from g()
 [out]
 main: note: In function "f":
 
@@ -755,8 +792,8 @@ main: note: In function "f":
 from typing import Iterator
 def g() -> Iterator[int]:
     yield 42
-def f() -> int:
-    yield from g()  # E: Iterable function return type expected for "yield from"
+def f() -> int:  # E: The return type of a generator function should be "Generator" or one of its supertypes
+    yield from g()
 [out]
 main: note: In function "f":
 

--- a/mypy/test/data/check-statements.test
+++ b/mypy/test/data/check-statements.test
@@ -66,6 +66,21 @@ def f() -> Generator[int, None, str]:
 [out]
 main: note: In function "f":
 
+[case testEmptyReturnInNoneTypedGenerator]
+from typing import Generator
+def f() -> Generator[int, None, None]:
+    yield 1
+    return
+[out]
+
+[case testNonEmptyReturnInNoneTypedGenerator]
+from typing import Generator
+def f() -> Generator[int, None, None]:
+    yield 1
+    return 42  # E: No return value expected
+[out]
+main: note: In function "f":
+
 [case testReturnInIterator]
 from typing import Iterator
 def f() -> Iterator[int]:

--- a/mypy/test/data/lib-stub/typing.py
+++ b/mypy/test/data/lib-stub/typing.py
@@ -53,6 +53,9 @@ class Generator(Iterator[T], Generic[T, U, V]):
     @abstractmethod
     def close(self) -> None: pass
 
+    @abstractmethod
+    def __iter__(self) -> 'Generator[T, U, V]': pass
+
 class Sequence(Generic[T]):
     @abstractmethod
     def __getitem__(self, n: Any) -> T: pass

--- a/mypy/test/data/parse.test
+++ b/mypy/test/data/parse.test
@@ -1338,11 +1338,12 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      YieldStmt:2(
-        OpExpr:2(
-          +
-          NameExpr(x)
-          IntExpr(1))))))
+      ExpressionStmt:2(
+        YieldExpr:2(
+          OpExpr:2(
+            +
+            NameExpr(x)
+            IntExpr(1)))))))
 
 [case testYieldFrom]
 def f():
@@ -1352,10 +1353,11 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      YieldFromStmt:2(
-        CallExpr:2(
-          NameExpr(h)
-          Args())))))
+      ExpressionStmt:2(
+        YieldFromExpr:2(
+          CallExpr:2(
+            NameExpr(h)
+            Args()))))))
 
 [case testYieldFromAssignment]
 def f():
@@ -2074,7 +2076,8 @@ MypyFile:1(
   FuncDef:1(
     f
     Block:1(
-      YieldStmt:2())))
+      ExpressionStmt:2(
+        YieldExpr:2()))))
 
 [case testConditionalExpression]
 x if y else z

--- a/mypy/test/data/pythoneval-asyncio.test
+++ b/mypy/test/data/pythoneval-asyncio.test
@@ -13,12 +13,12 @@ print('Imported')
 Imported
 
 [case testSimpleCoroutineSleep]
-from typing import Any
+from typing import Any, Generator
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def greet_every_two_seconds() -> 'Future[None]':
+def greet_every_two_seconds() -> 'Generator[Any, None, None]':
     n = 0
     while n < 5:
         print('Prev', n)
@@ -44,17 +44,18 @@ Prev 4
 After 4
 
 [case testCoroutineCallingOtherCoroutine]
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def compute(x: int, y: int) -> 'Future[int]':
+def compute(x: int, y: int) -> 'Generator[Any, None, int]':
     print("Compute %s + %s ..." % (x, y))
     yield from asyncio.sleep(0.1)
     return x + y   # Here the int is wrapped in Future[int]
 
 @asyncio.coroutine
-def print_sum(x: int, y: int) -> 'Future[None]':
+def print_sum(x: int, y: int) -> 'Generator[Any, None, None]':
     result = yield from compute(x, y)  # The type of result will be int (is extracted from Future[int]
     print("%s + %s = %s" % (x, y, result))
 
@@ -66,11 +67,12 @@ Compute 1 + 2 ...
 1 + 2 = 3
 
 [case testCoroutineChangingFuture]
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def slow_operation(future: 'Future[str]') -> 'Future[None]':
+def slow_operation(future: 'Future[str]') -> 'Generator[Any, None, None]':
     yield from asyncio.sleep(0.1)
     future.set_result('Future is done!')
 
@@ -85,11 +87,12 @@ Future is done!
 
 [case testFunctionAssignedAsCallback]
 import typing
+from typing import Generator, Any
 import asyncio
 from asyncio import Future, AbstractEventLoop
 
 @asyncio.coroutine
-def slow_operation(future: 'Future[str]') -> 'Future[None]':
+def slow_operation(future: 'Future[str]') -> 'Generator[Any, None, None]':
     yield from asyncio.sleep(1)
     future.set_result('Callback works!')
 
@@ -110,10 +113,11 @@ Callback works!
 
 [case testMultipleTasks]
 import typing
+from typing import Generator, Any
 import asyncio
 from asyncio import Task, Future
 @asyncio.coroutine
-def factorial(name, number) -> 'Future[None]':
+def factorial(name, number) -> 'Generator[Any, None, None]':
     f = 1
     for i in range(2, number+1):
         print("Task %s: Compute factorial(%s)..." % (name, i))
@@ -142,28 +146,29 @@ Task C: factorial(4) = 24
 
 [case testConcatenatedCoroutines]
 import typing
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def h4() -> 'Future[int]':
+def h4() -> 'Generator[Any, None, int]':
     x = yield from future
     return x
 
 @asyncio.coroutine
-def h3() -> 'Future[int]':
+def h3() -> 'Generator[Any, None, int]':
     x = yield from h4()
     print("h3: %s" % x)
     return x
 
 @asyncio.coroutine
-def h2() -> 'Future[int]':
+def h2() -> 'Generator[Any, None, int]':
     x = yield from h3()
     print("h2: %s" % x)
     return x
 
 @asyncio.coroutine
-def h() -> 'Future[None]':
+def h() -> 'Generator[Any, None, None]':
     x = yield from h2()
     print("h: %s" % x)
 
@@ -179,19 +184,20 @@ h2: 42
 h: 42
 Outside 42
 
-[case testConcantenatedCoroutinesReturningFutures]
+[case testConcatenatedCoroutinesReturningFutures]
 import typing
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def h4() -> 'Future[Future[int]]':
+def h4() -> 'Generator[Any, None, Future[int]]':
     yield from asyncio.sleep(0.1)
     f = asyncio.Future() #type: Future[int]
     return f
 
 @asyncio.coroutine
-def h3() -> 'Future[Future[Future[int]]]':
+def h3() -> 'Generator[Any, None, Future[Future[int]]]':
     x = yield from h4()
     x.set_result(42)
     f = asyncio.Future() #type: Future[Future[int]]
@@ -199,7 +205,7 @@ def h3() -> 'Future[Future[Future[int]]]':
     return f
 
 @asyncio.coroutine
-def h() -> 'Future[None]':
+def h() -> 'Generator[Any, None, None]':
     print("Before")
     x = yield from h3()
     y = yield from x
@@ -224,6 +230,7 @@ Future<result=Future<result=42>>
 
 [case testCoroutineWithOwnClass]
 import typing
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
@@ -232,7 +239,7 @@ class A:
         self.x = x
 
 @asyncio.coroutine
-def h() -> 'Future[None]':
+def h() -> 'Generator[Any, None, None]':
     x = yield from future
     print("h: %s" % x.x)
 
@@ -250,17 +257,17 @@ Outside 42
 -- Errors
 
 [case testErrorAssigningCoroutineThatDontReturn]
-from typing import Any
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def greet() -> 'Future[None]':
+def greet() -> 'Generator[Any, None, None]':
     yield from asyncio.sleep(0.2)
     print('Hello World')
 
 @asyncio.coroutine
-def test() -> 'Future[None]':
+def test() -> 'Generator[Any, None, None]':
     yield from greet()
     x = yield from greet()  # Error
 
@@ -274,17 +281,18 @@ _program.py: note: In function "test":
 _program.py:13: error: Function does not return a value
 
 [case testErrorReturnIsNotTheSameType]
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def compute(x: int, y: int) -> 'Future[int]':
+def compute(x: int, y: int) -> 'Generator[Any, None, int]':
     print("Compute %s + %s ..." % (x, y))
     yield from asyncio.sleep(0.1)
     return str(x + y)   # Error
 
 @asyncio.coroutine
-def print_sum(x: int, y: int) -> 'Future[None]':
+def print_sum(x: int, y: int) -> 'Generator[Any, None, None]':
     result = yield from compute(x, y)
     print("%s + %s = %s" % (x, y, result))
 
@@ -294,14 +302,15 @@ loop.close()
 
 [out]
 _program.py: note: In function "compute":
-_program.py:8: error: Incompatible return value type: expected asyncio.futures.Future[builtins.int], got asyncio.futures.Future[builtins.str]
+_program.py:9: error: Incompatible return value type: expected builtins.int, got builtins.str
 
 [case testErrorSetFutureDifferentInternalType]
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def slow_operation(future: 'Future[str]') -> 'Future[None]':
+def slow_operation(future: 'Future[str]') -> 'Generator[Any, None, None]':
     yield from asyncio.sleep(1)
     future.set_result(42)  # Error
 
@@ -313,15 +322,16 @@ print(future.result())
 loop.close()
 [out]
 _program.py: note: In function "slow_operation":
-_program.py:7: error: Argument 1 to "set_result" of "Future" has incompatible type "int"; expected "str"
+_program.py:8: error: Argument 1 to "set_result" of "Future" has incompatible type "int"; expected "str"
 
 
 [case testErrorUsingDifferentFutureType]
+from typing import Any, Generator
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def slow_operation(future: 'Future[int]') -> 'Future[None]':
+def slow_operation(future: 'Future[int]') -> 'Generator[Any, None, None]':
     yield from asyncio.sleep(1)
     future.set_result(42)
 
@@ -332,14 +342,15 @@ loop.run_until_complete(future)
 print(future.result())
 loop.close()
 [out]
-_program.py:11: error: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
+_program.py:12: error: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
 
 [case testErrorUsingDifferentFutureTypeAndSetFutureDifferentInternalType]
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
 asyncio.coroutine
-def slow_operation(future: 'Future[int]') -> 'Future[None]':
+def slow_operation(future: 'Future[int]') -> 'Generator[Any, None, None]':
     yield from asyncio.sleep(1)
     future.set_result('42')  #Try to set an str as result to a Future[int]
 
@@ -351,17 +362,18 @@ print(future.result())
 loop.close()
 [out]
 _program.py: note: In function "slow_operation":
-_program.py:7: error: Argument 1 to "set_result" of "Future" has incompatible type "str"; expected "int"
+_program.py:8: error: Argument 1 to "set_result" of "Future" has incompatible type "str"; expected "int"
 _program.py: note: At top level:
-_program.py:11: error: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
+_program.py:12: error: Argument 1 to "slow_operation" has incompatible type Future[str]; expected Future[int]
 
 [case testErrorSettingCallbackWithDifferentFutureType]
 import typing
+from typing import Generator, Any
 import asyncio
 from asyncio import Future, AbstractEventLoop
 
 @asyncio.coroutine
-def slow_operation(future: 'Future[str]') -> 'Future[None]':
+def slow_operation(future: 'Future[str]') -> 'Generator[Any, None, None]':
     yield from asyncio.sleep(1)
     future.set_result('Future is done!')
 
@@ -379,21 +391,22 @@ try:
 finally:
     loop.close()
 [out]
-_program.py:17: error: Argument 1 to "add_done_callback" of "Future" has incompatible type Callable[[Future[int]], None]; expected Callable[[Future[str]], Any]
+_program.py:18: error: Argument 1 to "add_done_callback" of "Future" has incompatible type Callable[[Future[int]], None]; expected Callable[[Future[str]], Any]
 
 [case testErrorOneMoreFutureInReturnType]
 import typing
+from typing import Any, Generator
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def h4() -> 'Future[Future[int]]':
+def h4() -> 'Generator[Any, None, Future[int]]':
     yield from asyncio.sleep(1)
     f = asyncio.Future() #type: Future[int]
     return f
 
 @asyncio.coroutine
-def h3() -> 'Future[Future[Future[Future[int]]]]':
+def h3() -> 'Generator[Any, None, Future[Future[Future[int]]]]':
     x = yield from h4()
     x.set_result(42)
     f = asyncio.Future() #type: Future[Future[int]]
@@ -401,7 +414,7 @@ def h3() -> 'Future[Future[Future[Future[int]]]]':
     return f
 
 @asyncio.coroutine
-def h() -> 'Future[None]':
+def h() -> 'Generator[Any, None, None]':
     print("Before")
     x = yield from h3()
     y = yield from x
@@ -415,21 +428,22 @@ loop.run_until_complete(h())
 loop.close()
 [out]
 _program.py: note: In function "h3":
-_program.py:17: error: Incompatible return value type: expected asyncio.futures.Future[asyncio.futures.Future[asyncio.futures.Future[asyncio.futures.Future[builtins.int]]]], got asyncio.futures.Future[asyncio.futures.Future[builtins.int]]
+_program.py:18: error: Incompatible return value type: expected asyncio.futures.Future[asyncio.futures.Future[asyncio.futures.Future[builtins.int]]], got asyncio.futures.Future[asyncio.futures.Future[builtins.int]]
 
 [case testErrorOneLessFutureInReturnType]
 import typing
+from typing import Any, Generator
 import asyncio
 from asyncio import Future
 
 @asyncio.coroutine
-def h4() -> 'Future[Future[int]]':
+def h4() -> 'Generator[Any, None, Future[int]]':
     yield from asyncio.sleep(1)
     f = asyncio.Future() #type: Future[int]
     return f
 
 @asyncio.coroutine
-def h3() -> 'Future[Future[int]]':
+def h3() -> 'Generator[Any, None, Future[int]]':
     x = yield from h4()
     x.set_result(42)
     f = asyncio.Future() #type: Future[Future[int]]
@@ -437,7 +451,7 @@ def h3() -> 'Future[Future[int]]':
     return f
 
 @asyncio.coroutine
-def h() -> 'Future[None]':
+def h() -> 'Generator[Any, None, None]':
     print("Before")
     x = yield from h3()
     y = yield from x
@@ -449,10 +463,11 @@ loop.run_until_complete(h())
 loop.close()
 [out]
 _program.py: note: In function "h3":
-_program.py:17: error: Incompatible return value type: expected asyncio.futures.Future[asyncio.futures.Future[builtins.int]], got asyncio.futures.Future[asyncio.futures.Future[builtins.int]]
+_program.py:18: error: Incompatible return value type: expected asyncio.futures.Future[builtins.int], got asyncio.futures.Future[asyncio.futures.Future[builtins.int]]
 
 [case testErrorAssignmentDifferentType]
 import typing
+from typing import Generator, Any
 import asyncio
 from asyncio import Future
 
@@ -465,7 +480,7 @@ class B:
         self.x = x
 
 @asyncio.coroutine
-def h() -> 'Future[None]':
+def h() -> 'Generator[Any, None, None]':
     x = yield from future # type: B # Error
     print("h: %s" % x.x)
 
@@ -476,4 +491,4 @@ loop.run_until_complete(h())
 loop.close()
 [out]
 _program.py: note: In function "h":
-_program.py:15: error: Incompatible types in assignment (expression has type "A", variable has type "B")
+_program.py:16: error: Incompatible types in assignment (expression has type "A", variable has type "B")

--- a/mypy/test/data/semanal-statements.test
+++ b/mypy/test/data/semanal-statements.test
@@ -32,8 +32,9 @@ MypyFile:1(
     f
     Generator
     Block:1(
-      YieldStmt:1(
-        NameExpr(f [__main__.f])))))
+      ExpressionStmt:1(
+        YieldExpr:1(
+          NameExpr(f [__main__.f]))))))
 
 [case testAssert]
 assert object

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -6,11 +6,11 @@ from mypy.visitor import NodeVisitor
 from mypy.nodes import (
     Block, MypyFile, FuncItem, CallExpr, ClassDef, Decorator, FuncDef,
     ExpressionStmt, AssignmentStmt, OperatorAssignmentStmt, WhileStmt,
-    ForStmt, ReturnStmt, AssertStmt, YieldStmt, DelStmt, IfStmt, RaiseStmt,
+    ForStmt, ReturnStmt, AssertStmt, DelStmt, IfStmt, RaiseStmt,
     TryStmt, WithStmt, MemberExpr, OpExpr, SliceExpr, CastExpr,
     UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr, IndexExpr,
     GeneratorExpr, ListComprehension, ConditionalExpr, TypeApplication,
-    FuncExpr, ComparisonExpr, OverloadedFuncDef, YieldFromStmt, YieldFromExpr,
+    FuncExpr, ComparisonExpr, OverloadedFuncDef, YieldFromExpr,
     YieldExpr
 )
 
@@ -94,14 +94,6 @@ class TraverserVisitor(NodeVisitor[T], Generic[T]):
             o.expr.accept(self)
 
     def visit_assert_stmt(self, o: AssertStmt) -> T:
-        if o.expr is not None:
-            o.expr.accept(self)
-
-    def visit_yield_stmt(self, o: YieldStmt) -> T:
-        if o.expr is not None:
-            o.expr.accept(self)
-
-    def visit_yield_from_stmt(self, o: YieldFromStmt) -> T:
         if o.expr is not None:
             o.expr.accept(self)
 

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -9,14 +9,14 @@ from mypy.nodes import (
     MypyFile, Import, Node, ImportAll, ImportFrom, FuncItem, FuncDef,
     OverloadedFuncDef, ClassDef, Decorator, Block, Var,
     OperatorAssignmentStmt, ExpressionStmt, AssignmentStmt, ReturnStmt,
-    RaiseStmt, AssertStmt, YieldStmt, DelStmt, BreakStmt, ContinueStmt,
+    RaiseStmt, AssertStmt, DelStmt, BreakStmt, ContinueStmt,
     PassStmt, GlobalDecl, WhileStmt, ForStmt, IfStmt, TryStmt, WithStmt,
     CastExpr, TupleExpr, GeneratorExpr, ListComprehension, ListExpr,
     ConditionalExpr, DictExpr, SetExpr, NameExpr, IntExpr, StrExpr, BytesExpr,
     UnicodeExpr, FloatExpr, CallExpr, SuperExpr, MemberExpr, IndexExpr,
     SliceExpr, OpExpr, UnaryExpr, FuncExpr, TypeApplication, PrintStmt,
     SymbolTable, RefExpr, TypeVarExpr, PromoteExpr,
-    ComparisonExpr, TempNode, StarExpr, YieldFromStmt,
+    ComparisonExpr, TempNode, StarExpr,
     YieldFromExpr, NamedTupleExpr, NonlocalDecl, SetComprehension,
     DictionaryComprehension, ComplexExpr, TypeAliasExpr, EllipsisExpr,
     YieldExpr, ExecStmt, Argument, BackquoteExpr
@@ -239,12 +239,6 @@ class TransformVisitor(NodeVisitor[Node]):
 
     def visit_assert_stmt(self, node: AssertStmt) -> Node:
         return AssertStmt(self.node(node.expr))
-
-    def visit_yield_stmt(self, node: YieldStmt) -> Node:
-        return YieldStmt(self.node(node.expr))
-
-    def visit_yield_from_stmt(self, node: YieldFromStmt) -> Node:
-        return YieldFromStmt(self.node(node.expr))
 
     def visit_del_stmt(self, node: DelStmt) -> Node:
         return DelStmt(self.node(node.expr))

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -85,12 +85,6 @@ class NodeVisitor(Generic[T]):
     def visit_assert_stmt(self, o: 'mypy.nodes.AssertStmt') -> T:
         pass
 
-    def visit_yield_stmt(self, o: 'mypy.nodes.YieldStmt') -> T:
-        pass
-
-    def visit_yield_from_stmt(self, o: 'mypy.nodes.YieldFromStmt') -> T:
-        pass
-
     def visit_del_stmt(self, o: 'mypy.nodes.DelStmt') -> T:
         pass
 


### PR DESCRIPTION
This commit fixes up the handling of Generators in several ways:
- it removes YieldStmt and YieldFromStmt, because they unnecessarily
  duplicate ExpressionStmt of YieldExpr/YieldFromExpr
- it ensures functions are properly marked as is_generator when
  appropriate
- it fixes a parsing bug where empty yield expressions would cause a parse
  error
- it checks Generator functions for the appropriate type signature at
  the function level, rather than at the yield statement level
- it adds support for return statements in Generator functions

fixes #20, fixes #836, fixes #695, fixes #633, fixes #498 