### PR TITLE
Add line number to "__init__ must return None" error

### DIFF
--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -425,7 +425,8 @@ class Parser:
                         arg_kinds,
                         arg_names,
                         sig.ret_type,
-                        None)
+                        None,
+                        line=def_tok.line)
                 else:
                     self.check_argument_kinds(arg_kinds, sig.arg_kinds,
                                               def_tok.line)
@@ -434,7 +435,8 @@ class Parser:
                         arg_kinds,
                         arg_names,
                         sig.ret_type,
-                        None)
+                        None,
+                        line=def_tok.line)
 
             # If there was a serious error, we really cannot build a parse tree
             # node.

--- a/mypy/test/data/check-basic.test
+++ b/mypy/test/data/check-basic.test
@@ -303,3 +303,12 @@ x in 1,
 if x in 1, :
     pass
 [out]
+
+[case testInitReturnTypeError]
+class C:
+    def __init__(self):
+        # type: () -> int
+        pass
+[out]
+main: note: In member "__init__" of class "C":
+main:2: error: The return type of "__init__" must be None


### PR DESCRIPTION
This is only a problem in Python 2, so it wasn't caught by the unit tests.  This PR associates the line number with the type when parsing.