### PR TITLE
Cache most searches for modules through the path

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -347,6 +347,7 @@ class BuildManager:
         self.type_checker = TypeChecker(self.errors, modules, self.pyversion)
         self.states = []  # type: List[State]
         self.module_files = {}  # type: Dict[str, str]
+        self.module_path_cache = {}  # type: Dict[str, str]  # includes modules we don't process
         self.module_deps = {}  # type: Dict[Tuple[str, str], bool]
         self.missing_modules = set()  # type: Set[str]
 
@@ -529,7 +530,12 @@ class BuildManager:
 
     def is_module(self, id: str) -> bool:
         """Is there a file in the file system corresponding to module id?"""
-        return find_module(id, self.lib_path) is not None
+        return self.find_module(id) is not None
+
+    def find_module(self, id: str) -> str:
+        if id not in self.module_path_cache:
+            self.module_path_cache[id] = find_module(id, self.lib_path)
+        return self.module_path_cache[id]
 
     def final_passes(self, files: List[MypyFile],
                      types: Dict[Node, Type]) -> None:


### PR DESCRIPTION
In type-checking one codebase of about 50 files and 150 direct
dependencies with --silent, we were spending 4.0s out of 8.2s
in find_module, of which 3.8s was in is_module, and the bulk of
those were duplicate calls.

Adding this cache cut out 89% of the total time spent in
find_module, and 44% of all the time spent in the whole program.
Now find_module is just under 10% of the time.

We could probably gain another few percent by caching other
calls to find_module too.  This is more complicated because
we don't necessarily always use the same lib_path -- leave
it for a subsequent diff.