### PR TITLE
Further optimize find_module

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -146,6 +146,8 @@ def build(sources: List[BuildSource],
 
     data_dir = default_data_dir(bin_dir)
 
+    find_module_clear_caches()
+
     # Determine the default module search path.
     lib_path = default_lib_path(data_dir, pyversion, python_path)
 
@@ -950,6 +952,12 @@ find_module_cache = {}  # type: Dict[Tuple[str, Tuple[str, ...]], str]
 # in the last component.
 find_module_dir_cache = {}  # type: Dict[Tuple[str, Tuple[str, ...]], List[str]]
 
+
+def find_module_clear_caches():
+    find_module_cache.clear()
+    find_module_dir_cache.clear()
+
+
 def find_module(id: str, lib_path: Iterable[str]) -> str:
     """Return the path of the module source file, or None if not found."""
     if not isinstance(lib_path, tuple):
@@ -965,7 +973,8 @@ def find_module(id: str, lib_path: Iterable[str]) -> str:
         if (dir_chain, lib_path) not in find_module_dir_cache:
             dirs = []
             for pathitem in lib_path:
-                dir = os.path.join(pathitem, dir_chain)  # e.g., '/usr/lib/python3.4/foo/bar'
+                # e.g., '/usr/lib/python3.4/foo/bar'
+                dir = os.path.normpath(os.path.join(pathitem, dir_chain))
                 if os.path.isdir(dir):
                     dirs.append(dir)
             find_module_dir_cache[dir_chain, lib_path] = dirs

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -975,11 +975,14 @@ def find_module(id: str, lib_path: Iterable[str]) -> str:
         # contains just the subdirectories 'foo/bar' that actually exist under the
         # elements of lib_path.  This is probably much shorter than lib_path itself.
         # Now just look for 'baz.pyi', 'baz/__init__.py', etc., inside those directories.
+        seplast = os.sep + components[-1]  # so e.g. '/baz'
+        sepinit = os.sep + '__init__'
         for base_dir in candidate_base_dirs:
+            base_path = base_dir + seplast  # so e.g. '/usr/lib/python3.4/foo/bar/baz'
             for extension in PYTHON_EXTENSIONS:
-                path = os.path.join(base_dir, components[-1] + extension)
+                path = base_path + extension
                 if not os.path.isfile(path):
-                    path = os.path.join(base_dir, components[-1], '__init__{}'.format(extension))
+                    path = base_path + sepinit + extension
                 if os.path.isfile(path) and verify_module(id, path):
                     return path
         return None


### PR DESCRIPTION
These three commits take the time we spend in find_module on an example codebase from 10% of mypy's total time down to 1.4%. At this point I think I'm done optimizing this for a while. :-)

The main improvement is the middle commit, which caches a lot of work that is otherwise repeated between find_module calls.
