### PR TITLE
Give `CompileError` a message.

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -340,7 +340,7 @@ class CompileError(Exception):
     messages = None  # type: List[str]
 
     def __init__(self, messages: List[str]) -> None:
-        super().__init__()
+        super().__init__('\n'.join(messages))
         self.messages = messages
 
 


### PR DESCRIPTION
fix #1200

-- 
I'm joining with `\n` because I guess when there are many error messages they are ment to be one by line. 