### PR TITLE
Error out on .pyc files.  Fixes #1204

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -302,6 +302,9 @@ def read_program(path: str, pyversion: Tuple[int, int]) -> str:
     except IOError as ioerr:
         raise CompileError([
             "mypy: can't read file '{}': {}".format(path, ioerr.strerror)])
+    except UnicodeDecodeError as decodeerr:
+        raise CompileError([
+            "mypy: can't decode file '{}': {}".format(path, str(decodeerr))])
     return text
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -197,8 +197,6 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
             targets.append(BuildSource(arg, crawl_up(arg)[1], None))
         elif os.path.isdir(arg):
             targets.extend(expand_dir(arg))
-        elif arg.endswith('.pyc'):
-            fail("Can't check .pyc files: '{}'".format(arg))
         else:
             targets.append(BuildSource(arg, None, None))
     return targets, options

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -197,6 +197,8 @@ def process_options(args: List[str]) -> Tuple[List[BuildSource], Options]:
             targets.append(BuildSource(arg, crawl_up(arg)[1], None))
         elif os.path.isdir(arg):
             targets.extend(expand_dir(arg))
+        elif arg.endswith('.pyc'):
+            fail("Can't check .pyc files: '{}'".format(arg))
         else:
             targets.append(BuildSource(arg, None, None))
     return targets, options


### PR DESCRIPTION
Print an error when given one or more .pyc files as input.  This is intended to fix #1204.  

This seems like a simple enough fix, but I'm new to this project so please let me know if there are subtleties I'm missing here.  